### PR TITLE
chore: bump typescript and contentful-management

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "@types/mocha": "^9.0.0",
         "@types/node": "^16.11.68",
         "chai": "^4",
-        "contentful-management": "^10.19.0",
+        "contentful-management": "^10.35.4",
         "eslint": "^7.32.0",
         "eslint-config-oclif": "^4",
         "eslint-config-oclif-typescript": "^1.0.3",
@@ -42,7 +42,7 @@
         "shx": "^0.3.3",
         "ts-node": "^10.9.1",
         "tslib": "^2.3.1",
-        "typescript": "^4.8.4"
+        "typescript": "^5.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -526,6 +526,15 @@
       },
       "engines": {
         "node": ">=8.17.0"
+      }
+    },
+    "node_modules/@contentful/rich-text-types": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/@contentful/rich-text-types/-/rich-text-types-16.2.0.tgz",
+      "integrity": "sha512-4BHC+mfa50JB70epzpnas4EkiuB3mGdBZ5Rp8w7R5wXvswEf8TLg5yGau2FxmZeEjrAkDrt4vzBLVQ8v3Y//Jw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -2832,20 +2841,39 @@
       "license": "MIT"
     },
     "node_modules/contentful-management": {
-      "version": "10.19.0",
-      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-10.19.0.tgz",
-      "integrity": "sha512-4cwHoIOw2zVewStaMTQjDesuYPzzC32GlzZlQVfjiY1Z9runiPZo+WlFbGzZdqBpTebrlU/v+KUPvZdxJzQ8hQ==",
+      "version": "10.35.4",
+      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-10.35.4.tgz",
+      "integrity": "sha512-yAgnwzyyT3kqvxKkM6iky9UiWs8n1EQH5n52rcBrjHM44Ext+Kjagzz1gRQC3maYSgp5UR3FwyUj8gX9Kd7uDQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
+        "@contentful/rich-text-types": "^16.0.3",
         "@types/json-patch": "0.0.30",
         "axios": "^0.27.1",
         "contentful-sdk-core": "^7.0.1",
-        "fast-copy": "^2.1.1",
-        "lodash.isplainobject": "^4.0.6"
+        "fast-copy": "^3.0.0",
+        "lodash.isplainobject": "^4.0.6",
+        "type-fest": "^3.0.0"
       },
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/contentful-management/node_modules/fast-copy": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-3.0.1.tgz",
+      "integrity": "sha512-Knr7NOtK3HWRYGtHoJrjkaWepqT8thIVGAwt0p0aUs1zqkAzXZV4vo9fFNwyb5fcqK1GKYFYxldQdIDVKhUAfA==",
+      "dev": true
+    },
+    "node_modules/contentful-management/node_modules/type-fest": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.11.0.tgz",
+      "integrity": "sha512-JaPw5U9ixP0XcpUbQoVSbxSDcK/K4nww20C3kjm9yE6cDRRhptU28AH60VWf9ltXmCrIfIbtt9J+2OUk2Uqiaw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/contentful-resolve-response": {
@@ -8993,17 +9021,16 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
-      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
+      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
       "dev": true,
-      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=12.20"
       }
     },
     "node_modules/unique-filename": {
@@ -10192,6 +10219,12 @@
       "requires": {
         "diff-match-patch": "^1.0.5"
       }
+    },
+    "@contentful/rich-text-types": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/@contentful/rich-text-types/-/rich-text-types-16.2.0.tgz",
+      "integrity": "sha512-4BHC+mfa50JB70epzpnas4EkiuB3mGdBZ5Rp8w7R5wXvswEf8TLg5yGau2FxmZeEjrAkDrt4vzBLVQ8v3Y//Jw==",
+      "dev": true
     },
     "@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -11857,16 +11890,32 @@
       "integrity": "sha512-AvrnEeMTJtRy9SeuHrLbk/bntLwEE9FrhPfFcBp08md0Nz3N7a2+SmZgF5ZTyBRVc9pHjg+Fg6+O5c9q7Tj5HQ=="
     },
     "contentful-management": {
-      "version": "10.19.0",
-      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-10.19.0.tgz",
-      "integrity": "sha512-4cwHoIOw2zVewStaMTQjDesuYPzzC32GlzZlQVfjiY1Z9runiPZo+WlFbGzZdqBpTebrlU/v+KUPvZdxJzQ8hQ==",
+      "version": "10.35.4",
+      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-10.35.4.tgz",
+      "integrity": "sha512-yAgnwzyyT3kqvxKkM6iky9UiWs8n1EQH5n52rcBrjHM44Ext+Kjagzz1gRQC3maYSgp5UR3FwyUj8gX9Kd7uDQ==",
       "dev": true,
       "requires": {
+        "@contentful/rich-text-types": "^16.0.3",
         "@types/json-patch": "0.0.30",
         "axios": "^0.27.1",
         "contentful-sdk-core": "^7.0.1",
-        "fast-copy": "^2.1.1",
-        "lodash.isplainobject": "^4.0.6"
+        "fast-copy": "^3.0.0",
+        "lodash.isplainobject": "^4.0.6",
+        "type-fest": "^3.0.0"
+      },
+      "dependencies": {
+        "fast-copy": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-3.0.1.tgz",
+          "integrity": "sha512-Knr7NOtK3HWRYGtHoJrjkaWepqT8thIVGAwt0p0aUs1zqkAzXZV4vo9fFNwyb5fcqK1GKYFYxldQdIDVKhUAfA==",
+          "dev": true
+        },
+        "type-fest": {
+          "version": "3.11.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.11.0.tgz",
+          "integrity": "sha512-JaPw5U9ixP0XcpUbQoVSbxSDcK/K4nww20C3kjm9yE6cDRRhptU28AH60VWf9ltXmCrIfIbtt9J+2OUk2Uqiaw==",
+          "dev": true
+        }
       }
     },
     "contentful-resolve-response": {
@@ -16109,9 +16158,9 @@
       }
     },
     "typescript": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
-      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
+      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
       "dev": true
     },
     "unique-filename": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@types/mocha": "^9.0.0",
     "@types/node": "^16.11.68",
     "chai": "^4",
-    "contentful-management": "^10.19.0",
+    "contentful-management": "^10.35.4",
     "eslint": "^7.32.0",
     "eslint-config-oclif": "^4",
     "eslint-config-oclif-typescript": "^1.0.3",
@@ -48,7 +48,7 @@
     "shx": "^0.3.3",
     "ts-node": "^10.9.1",
     "tslib": "^2.3.1",
-    "typescript": "^4.8.4"
+    "typescript": "^5.0.4"
   },
   "oclif": {
     "bin": "ccccli",


### PR DESCRIPTION
Bumping to get rid of a few of the errors we currently run into on `npm run build`