### PR TITLE
fix: bump jsondiffpatch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/jsondiffpatch": "^1.2.0",
+        "@contentful/jsondiffpatch": "^1.3.1",
         "@oclif/core": "^1.20.2",
         "@oclif/plugin-plugins": "^2.1.6",
         "axios": "^0.27.2",
@@ -514,10 +514,9 @@
       }
     },
     "node_modules/@contentful/jsondiffpatch": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@contentful/jsondiffpatch/-/jsondiffpatch-1.2.0.tgz",
-      "integrity": "sha512-AG2z3ayrW3VM85FMiK2mSjAqPRSLfYC4ic3vgOrJvdp2akk3vUcwBhUzrJae86vdtNfvMOc7owLcSD+YLxHXyA==",
-      "license": "MIT",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@contentful/jsondiffpatch/-/jsondiffpatch-1.3.1.tgz",
+      "integrity": "sha512-VKCj1JGHdlkXeG6/Tbfmub5mcDHrHyodcvlYRJfm9iHm4HW5M4OiFtwdrxZxaNG6ACyNMvnsfRITOA+BeV6YTw==",
       "dependencies": {
         "diff-match-patch": "^1.0.5"
       },
@@ -525,7 +524,7 @@
         "jsondiffpatch": "bin/jsondiffpatch"
       },
       "engines": {
-        "node": ">=8.17.0"
+        "node": ">=18"
       }
     },
     "node_modules/@contentful/rich-text-types": {
@@ -10213,9 +10212,9 @@
       }
     },
     "@contentful/jsondiffpatch": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@contentful/jsondiffpatch/-/jsondiffpatch-1.2.0.tgz",
-      "integrity": "sha512-AG2z3ayrW3VM85FMiK2mSjAqPRSLfYC4ic3vgOrJvdp2akk3vUcwBhUzrJae86vdtNfvMOc7owLcSD+YLxHXyA==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@contentful/jsondiffpatch/-/jsondiffpatch-1.3.1.tgz",
+      "integrity": "sha512-VKCj1JGHdlkXeG6/Tbfmub5mcDHrHyodcvlYRJfm9iHm4HW5M4OiFtwdrxZxaNG6ACyNMvnsfRITOA+BeV6YTw==",
       "requires": {
         "diff-match-patch": "^1.0.5"
       }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "/oclif.manifest.json"
   ],
   "dependencies": {
-    "@contentful/jsondiffpatch": "^1.2.0",
+    "@contentful/jsondiffpatch": "^1.3.1",
     "@oclif/core": "^1.20.2",
     "@oclif/plugin-plugins": "^2.1.6",
     "axios": "^0.27.2",


### PR DESCRIPTION
Bumps json diff patch to latest so that now `npm run build` won't have type issues anymore.