### PR TITLE
chore: add vault basic setup for dependabot []

### DIFF
--- a/.contentful/vault-secrets.yaml
+++ b/.contentful/vault-secrets.yaml
@@ -1,0 +1,5 @@
+version: 1
+services:
+  github-action:
+    policies:
+    - dependabot


### PR DESCRIPTION
This policy has to be made available to dependabot so that it can auto-merge.