### PR TITLE
fix: ignore mayer version updates []

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,12 +3,14 @@ updates:
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
-      # interval: daily
-      # time: "00:00"
-      # timezone: UTC
+      interval: daily
+      time: "15:00"
+      timezone: UTC
     open-pull-requests-limit: 10
     commit-message:
       prefix: build
       include: scope
     ignore:
       - dependency-name: '@salesforce/dev-scripts'
+      - dependency-name: '*'
+        update-types: ['version-update:semver-major']


### PR DESCRIPTION
Reverting the ignore list of dependabot to how it looked in the original template.