### PR TITLE
fix: also update mayor version bumps with dependabot [PHX-2657]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
     directory: '/'
     schedule:
       interval: daily
-      time: "15:00"
+      time: "00:00"
       timezone: UTC
     open-pull-requests-limit: 10
     commit-message:
@@ -12,5 +12,3 @@ updates:
       include: scope
     ignore:
       - dependency-name: '@salesforce/dev-scripts'
-      - dependency-name: '*'
-        update-types: ['version-update:semver-major']


### PR DESCRIPTION
Also allow dependabot to do mayor version updates, and move the time back to night.

Should be merged after https://github.com/contentful/contentful-merge/pull/122 which is needed to properly block dependabot update attempts.