### PR TITLE
feat: add more logging to the task system [NONE]

### DIFF
--- a/src/engine/client/index.ts
+++ b/src/engine/client/index.ts
@@ -3,7 +3,7 @@ import { ContentTypeCollection, Entry, EntryCollection } from 'contentful'
 import { EntryProps } from 'contentful-management'
 import { createHttpClient, getUserAgentHeader } from 'contentful-sdk-core'
 import { pickBy } from 'lodash'
-import { ClientLogHandler } from '../logger/types'
+import { ClientLogHandler, ILogger, LogLevel } from '../logger/types'
 import { stripSys } from '../utils/strip-sys'
 
 import ContentfulSdkCorePKGJson from 'contentful-sdk-core/package.json'
@@ -89,30 +89,30 @@ export const createClient = ({
     cma: {
       requestCounts: () => count.cma,
       entries: {
-        getMany: async ({ environment, query }: GetEntriesParams) => {
+        getMany: async ({ environment, query }: GetEntriesParams, logger?: ILogger) => {
           count.cma++
           const result = await cmaClient.get(`${environment}/entries`, {
             params: { ...cleanQuery(query) },
           })
           return result.data as EntryCollection<any>
         },
-        get: async ({ environment, entryId, query }: GetEntryParams) => {
+        get: async ({ environment, entryId, query }: GetEntryParams, logger?: ILogger) => {
           count.cma++
           const result = await cmaClient.get(`${environment}/entries/${entryId}`, {
             params: { ...cleanQuery(query) },
           })
           return result.data as EntryProps<any>
         },
-        unpublish: async ({ environment, entryId }: DeleteEntryParams) => {
+        unpublish: async ({ environment, entryId }: DeleteEntryParams, logger?: ILogger) => {
           count.cma++
           const result = await cmaClient.delete(`${environment}/entries/${entryId}/published`)
           return result.data as EntryProps<any>
         },
-        delete: async ({ environment, entryId }: DeleteEntryParams) => {
+        delete: async ({ environment, entryId }: DeleteEntryParams, logger?: ILogger) => {
           count.cma++
           await cmaClient.delete(`${environment}/entries/${entryId}`)
         },
-        create: async ({ environment, entry, entryId, contentType }: CreateEntryParams) => {
+        create: async ({ environment, entry, entryId, contentType }: CreateEntryParams, logger?: ILogger) => {
           count.cma++
           const result = await cmaClient.put(`${environment}/entries/${entryId}`, stripSys(entry), {
             headers: {
@@ -121,7 +121,7 @@ export const createClient = ({
           })
           return result.data as EntryProps<any>
         },
-        update: async ({ environment, entry, entryId }: UpdateEntryParams) => {
+        update: async ({ environment, entry, entryId }: UpdateEntryParams, logger?: ILogger) => {
           count.cma++
           const result = await cmaClient.put(`${environment}/entries/${entryId}`, entry, {
             headers: {
@@ -130,7 +130,7 @@ export const createClient = ({
           })
           return result.data as EntryProps<any>
         },
-        publish: async ({ environment, entry, entryId }: PublishEntryParams) => {
+        publish: async ({ environment, entry, entryId }: PublishEntryParams, logger?: ILogger) => {
           count.cma++
           return cmaClient.put(`${environment}/entries/${entryId}/published`, entry, {
             headers: {
@@ -143,15 +143,17 @@ export const createClient = ({
     cda: {
       requestCounts: () => count.cda,
       entries: {
-        getMany: async ({ environment, query }: GetEntriesParams) => {
+        getMany: async ({ environment, query }: GetEntriesParams, logger?: ILogger) => {
           count.cda++
+          logger?.log(LogLevel.INFO, `"GET /${space}/${`${environment}/entries`} ${JSON.stringify(query)}"`)
           const result = await cdaClient.get(`${environment}/entries`, {
             params: { ...cleanQuery(query) },
           })
           return result.data as EntryCollection<any>
         },
-        get: async ({ environment, entryId, query }: GetEntryParams) => {
+        get: async ({ environment, entryId, query }: GetEntryParams, logger?: ILogger) => {
           count.cda++
+          logger?.log(LogLevel.INFO, `"GET /${space}/${environment}/entries/${entryId} ${JSON.stringify(query)}"`)
           const result = await cdaClient.get(`${environment}/entries/${entryId}`, {
             params: { ...cleanQuery(query) },
           })
@@ -159,8 +161,9 @@ export const createClient = ({
         },
       },
       contentTypes: {
-        getMany: async ({ environment, query }: GetEntriesParams) => {
+        getMany: async ({ environment, query }: GetEntriesParams, logger?: ILogger) => {
           count.cda++
+          logger?.log(LogLevel.INFO, `"GET ${`/${space}/${environment}/content_types`} ${JSON.stringify(query)}"`)
           const result = await cdaClient.get(`${environment}/content_types`, {
             params: { ...cleanQuery(query) },
           })

--- a/src/engine/create-changeset/tasks/create-affected-content-types-diverged-task.ts
+++ b/src/engine/create-changeset/tasks/create-affected-content-types-diverged-task.ts
@@ -2,13 +2,14 @@ import { CreateChangesetContext } from '../types'
 import { ListrTask } from 'listr2'
 import { LogLevel } from '../../logger/types'
 import { affectedEntitiesIds } from '../../utils/affected-entities-ids'
+import { createScopedLogger } from '../../logger/create-scoped-logger'
 
 export function createAffectedContentTypesDivergedTask(): ListrTask {
   return {
     title: `Checking for diverged content types`,
     task: async (context: CreateChangesetContext) => {
-      context.logger.log(LogLevel.INFO, `Start createAffectedContentTypesDivergedTask`)
-
+      const logger = createScopedLogger(context.logger, `CreateAffectedContentTypesDivergedTask`)
+      logger.startScope()
       const affectedContentTypeIds = affectedEntitiesIds(context.affectedEntities.contentTypes, [
         'added',
         'removed',
@@ -29,7 +30,7 @@ export function createAffectedContentTypesDivergedTask(): ListrTask {
       if (contentModelDiverged.length) {
         context.contentModelDiverged = true
       }
-
+      logger.stopScope()
       return context
     },
   }

--- a/src/engine/create-changeset/tasks/create-compute-ids-task.ts
+++ b/src/engine/create-changeset/tasks/create-compute-ids-task.ts
@@ -3,6 +3,7 @@ import { LogLevel } from '../../logger/types'
 import { CreateChangesetContext, EnvironmentScope } from '../types'
 import { doesExceedLimits } from '../../utils/exceeds-limits'
 import { EntityType } from '../../types'
+import { createScopedLogger } from '../../logger/create-scoped-logger'
 type ComputeIdsTaskProps = {
   entityType: EntityType
 }
@@ -11,8 +12,9 @@ export const createComputeIdsTask = ({ entityType }: ComputeIdsTaskProps): Listr
   return {
     title: `Counting number of ${entityType} changes between environments`,
     task: async (context: CreateChangesetContext) => {
-      const { sourceData, targetData, logger } = context
-      logger.log(LogLevel.INFO, `Start computeIdsTask ${[entityType]}`)
+      const { sourceData, targetData } = context
+      const logger = createScopedLogger(context.logger, `CreateComputeIdsTask '${entityType}'`)
+      logger.startScope()
 
       const added = new Set(sourceData[entityType].ids.filter((item) => !targetData[entityType].ids.includes(item)))
       const removed = new Set(targetData[entityType].ids.filter((item) => !sourceData[entityType].ids.includes(item)))
@@ -33,7 +35,7 @@ export const createComputeIdsTask = ({ entityType }: ComputeIdsTaskProps): Listr
 
       const exceedsLimits = doesExceedLimits(context, entityType)
       context.exceedsLimits = exceedsLimits
-
+      logger.stopScope()
       return Promise.resolve(context)
     },
   }

--- a/src/engine/logger/create-scoped-logger.ts
+++ b/src/engine/logger/create-scoped-logger.ts
@@ -1,0 +1,11 @@
+import { ILogger, LogLevel } from './types'
+
+export function createScopedLogger(logger: ILogger, scope: string) {
+  const scopeStr = `[${scope}]`
+  return {
+    ...logger,
+    log: (level: LogLevel, message?: string | Error | undefined) => logger.log(level, `${scopeStr}\t${message}`),
+    startScope: () => logger.log(LogLevel.INFO, `${scopeStr}\tSTART`),
+    stopScope: () => logger.log(LogLevel.INFO, `${scopeStr}\tDONE`),
+  }
+}


### PR DESCRIPTION
To ensure we have all relevant details when debugging the CLI, we add more details to our log file.

**Example output:** 

```
2023-07-17T09:34:33.768Z	INFO	CDA Throttle request to 30/s
2023-07-17T09:34:33.768Z	INFO	CMA Throttle request to 7/s
2023-07-17T09:34:33.799Z	INFO	[CreateEntitiesTask 'contentTypes']	START
2023-07-17T09:34:33.799Z	INFO	[CreateEntitiesTask 'contentTypes']	"GET /lnsjpb79eisl/test-cloned/content_types {"limit":0}"
2023-07-17T09:34:33.993Z	INFO	[CreateEntitiesTask 'contentTypes']	"GET /lnsjpb79eisl/test-cloned/content_types {"select":["sys.id","sys.updatedAt"],"limit":1000,"skip":0}"
2023-07-17T09:34:34.160Z	INFO	[CreateEntitiesTask 'contentTypes']	DONE
2023-07-17T09:34:34.162Z	INFO	[CreateEntitiesTask 'contentTypes']	START
2023-07-17T09:34:34.162Z	INFO	[CreateEntitiesTask 'contentTypes']	"GET /lnsjpb79eisl/test-cloned-diverged/content_types {"limit":0}"
2023-07-17T09:34:34.297Z	INFO	[CreateEntitiesTask 'contentTypes']	"GET /lnsjpb79eisl/test-cloned-diverged/content_types {"select":["sys.id","sys.updatedAt"],"limit":1000,"skip":0}"
2023-07-17T09:34:34.464Z	INFO	[CreateEntitiesTask 'contentTypes']	DONE
2023-07-17T09:34:34.466Z	INFO	[CreateComputeIdsTask 'contentTypes']	START
2023-07-17T09:34:34.466Z	INFO	[CreateComputeIdsTask 'contentTypes']	DONE
2023-07-17T09:34:34.486Z	INFO	[CreateEntitiesTask 'entries']	START
2023-07-17T09:34:34.486Z	INFO	[CreateEntitiesTask 'entries']	"GET /lnsjpb79eisl/test-cloned/entries {"limit":0}"
2023-07-17T09:34:34.615Z	INFO	[CreateEntitiesTask 'entries']	"GET /lnsjpb79eisl/test-cloned/entries {"select":["sys.id","sys.updatedAt","sys.contentType.sys.id"],"limit":1000,"skip":0}"
2023-07-17T09:34:34.615Z	INFO	[CreateEntitiesTask 'entries']	"GET /lnsjpb79eisl/test-cloned/entries {"select":["sys.id","sys.updatedAt","sys.contentType.sys.id"],"limit":1000,"skip":1000}"
2023-07-17T09:34:34.615Z	INFO	[CreateEntitiesTask 'entries']	"GET /lnsjpb79eisl/test-cloned/entries {"select":["sys.id","sys.updatedAt","sys.contentType.sys.id"],"limit":1000,"skip":2000}"
2023-07-17T09:34:34.615Z	INFO	[CreateEntitiesTask 'entries']	"GET /lnsjpb79eisl/test-cloned/entries {"select":["sys.id","sys.updatedAt","sys.contentType.sys.id"],"limit":1000,"skip":3000}"
2023-07-17T09:34:34.616Z	INFO	[CreateEntitiesTask 'entries']	"GET /lnsjpb79eisl/test-cloned/entries {"select":["sys.id","sys.updatedAt","sys.contentType.sys.id"],"limit":1000,"skip":4000}"
2023-07-17T09:34:34.616Z	INFO	[CreateEntitiesTask 'entries']	"GET /lnsjpb79eisl/test-cloned/entries {"select":["sys.id","sys.updatedAt","sys.contentType.sys.id"],"limit":1000,"skip":5000}"
2023-07-17T09:34:34.616Z	INFO	[CreateEntitiesTask 'entries']	"GET /lnsjpb79eisl/test-cloned/entries {"select":["sys.id","sys.updatedAt","sys.contentType.sys.id"],"limit":1000,"skip":6000}"
2023-07-17T09:34:34.920Z	INFO	[CreateEntitiesTask 'entries']	"GET /lnsjpb79eisl/test-cloned/entries {"select":["sys.id","sys.updatedAt","sys.contentType.sys.id"],"limit":1000,"skip":7000}"
2023-07-17T09:34:34.925Z	INFO	[CreateEntitiesTask 'entries']	"GET /lnsjpb79eisl/test-cloned/entries {"select":["sys.id","sys.updatedAt","sys.contentType.sys.id"],"limit":1000,"skip":8000}"
2023-07-17T09:34:34.933Z	INFO	[CreateEntitiesTask 'entries']	"GET /lnsjpb79eisl/test-cloned/entries {"select":["sys.id","sys.updatedAt","sys.contentType.sys.id"],"limit":1000,"skip":9000}"
2023-07-17T09:34:35.179Z	INFO	[CreateEntitiesTask 'entries']	DONE
2023-07-17T09:34:35.181Z	INFO	[CreateEntitiesTask 'entries']	START
2023-07-17T09:34:35.181Z	INFO	[CreateEntitiesTask 'entries']	"GET /lnsjpb79eisl/test-cloned-diverged/entries {"limit":0}"
2023-07-17T09:34:35.312Z	INFO	[CreateEntitiesTask 'entries']	"GET /lnsjpb79eisl/test-cloned-diverged/entries {"select":["sys.id","sys.updatedAt","sys.contentType.sys.id"],"limit":1000,"skip":0}"
2023-07-17T09:34:35.312Z	INFO	[CreateEntitiesTask 'entries']	"GET /lnsjpb79eisl/test-cloned-diverged/entries {"select":["sys.id","sys.updatedAt","sys.contentType.sys.id"],"limit":1000,"skip":1000}"
2023-07-17T09:34:35.312Z	INFO	[CreateEntitiesTask 'entries']	"GET /lnsjpb79eisl/test-cloned-diverged/entries {"select":["sys.id","sys.updatedAt","sys.contentType.sys.id"],"limit":1000,"skip":2000}"
2023-07-17T09:34:35.312Z	INFO	[CreateEntitiesTask 'entries']	"GET /lnsjpb79eisl/test-cloned-diverged/entries {"select":["sys.id","sys.updatedAt","sys.contentType.sys.id"],"limit":1000,"skip":3000}"
2023-07-17T09:34:35.312Z	INFO	[CreateEntitiesTask 'entries']	"GET /lnsjpb79eisl/test-cloned-diverged/entries {"select":["sys.id","sys.updatedAt","sys.contentType.sys.id"],"limit":1000,"skip":4000}"
2023-07-17T09:34:35.312Z	INFO	[CreateEntitiesTask 'entries']	"GET /lnsjpb79eisl/test-cloned-diverged/entries {"select":["sys.id","sys.updatedAt","sys.contentType.sys.id"],"limit":1000,"skip":5000}"
2023-07-17T09:34:35.313Z	INFO	[CreateEntitiesTask 'entries']	"GET /lnsjpb79eisl/test-cloned-diverged/entries {"select":["sys.id","sys.updatedAt","sys.contentType.sys.id"],"limit":1000,"skip":6000}"
2023-07-17T09:34:35.611Z	INFO	[CreateEntitiesTask 'entries']	"GET /lnsjpb79eisl/test-cloned-diverged/entries {"select":["sys.id","sys.updatedAt","sys.contentType.sys.id"],"limit":1000,"skip":7000}"
2023-07-17T09:34:35.616Z	INFO	[CreateEntitiesTask 'entries']	"GET /lnsjpb79eisl/test-cloned-diverged/entries {"select":["sys.id","sys.updatedAt","sys.contentType.sys.id"],"limit":1000,"skip":8000}"
2023-07-17T09:34:35.771Z	INFO	[CreateEntitiesTask 'entries']	"GET /lnsjpb79eisl/test-cloned-diverged/entries {"select":["sys.id","sys.updatedAt","sys.contentType.sys.id"],"limit":1000,"skip":9000}"
2023-07-17T09:34:36.404Z	INFO	[CreateEntitiesTask 'entries']	DONE
2023-07-17T09:34:36.406Z	INFO	[CreateComputeIdsTask 'entries']	START
2023-07-17T09:34:36.774Z	INFO	[CreateComputeIdsTask 'entries']	DONE
2023-07-17T09:34:36.775Z	INFO	[CreateAffectedContentTypesDivergedTask]	START
2023-07-17T09:34:36.776Z	INFO	[CreateAffectedContentTypesDivergedTask]	DONE
2023-07-17T09:34:36.777Z	INFO	[CreateFetchChangedTasks 'entries']	START
2023-07-17T09:34:36.778Z	INFO	[CreateFetchChangedTasks 'entries']	START
2023-07-17T09:34:36.779Z	INFO	[CreateFetchAddedEntitiesTask 'entries']	START
2023-07-17T09:34:36.781Z	INFO	[CreateFetchAddedEntitiesTask 'entries']	"GET /lnsjpb79eisl/test-cloned/entries {"sys.id[in]":"2gN0ksaG9WkbH3zxTt6PA8","locale":"*","limit":200}"
2023-07-17T09:34:36.909Z	INFO	[CreateFetchAddedEntitiesTask 'entries']	START
```