### PR TITLE
feat: don't show irrelevant entry stats when content model is diverged []

### DIFF
--- a/src/engine/create-changeset/errors.ts
+++ b/src/engine/create-changeset/errors.ts
@@ -1,8 +1,25 @@
 import { CreateChangesetContext } from '../create-changeset/types'
+// import { icons, pluralizeEntry, entityStatRenderer } from '../utils'
+
+// const entryChangeRenderer = entityStatRenderer({
+//   icon: icons.bulletPoint,
+//   pluralizer: pluralizeEntry,
+// })
 
 export class LimitsExceededError extends Error {
   constructor(context: CreateChangesetContext) {
     const message = `The detected number of entries to be compared, added or removed is too high.\nThe currently allowed limit is ${context.limits.all} entries.`
+
+    // const entriesAddedLength = context.affectedEntities.entries.added.length
+    // const entriesRemovedLength = context.affectedEntities.entries.removed.length
+    // const entriesMaybeChangedLength = context.affectedEntities.entries.maybeChanged.length
+
+    // message += `\nDetected number of changes:`
+    // message += '\n'
+    // message += `\n  ${entryChangeRenderer(entriesAddedLength, 'added')}`
+    // message += `\n  ${entryChangeRenderer(entriesRemovedLength, 'removed')}`
+    // message += `\n  ${entryChangeRenderer(entriesMaybeChangedLength)} to be compared`
+
     super(message)
   }
 }


### PR DESCRIPTION
We used to show details about entry changes in the error message about diverged content types. This provides no added value. This PR removes the stats, now we only show which content types have differences. 

<img width="1001" alt="image" src="https://github.com/contentful/contentful-merge/assets/33579339/cd06fa18-3c3c-48b9-932a-0e3c166d19b2">

______________________
**FAQ**
What is this good for? 
- Better UX, removes some redundant if else branching, will be much easier now to move also the diverged content model error to the new error handling.

Why does this PR have commented out code? 
- Because I deleted some from `render-output` that is still needed - but at another place (limits exceeded error). I put it there temporarily so we don't have to dig it out later. I did not spend time on how exactly we render this info as @ruderngespra is working on it atm, so I just put it there as a comment.