### PR TITLE
fix: reintroduce normal timeout for segment flush []

### DIFF
--- a/src/commands/create/index.ts
+++ b/src/commands/create/index.ts
@@ -213,6 +213,6 @@ export default class Create extends Command {
   protected async finally(): Promise<any> {
     // analyticsCloseAndFlush has a very short timeout because it will
     // otherwise trigger a rerender of the listr tasks on error exits
-    await Promise.allSettled([Sentry.close(2000), analyticsCloseAndFlush(1)])
+    await Promise.allSettled([Sentry.close(2000), analyticsCloseAndFlush(2000)])
   }
 }


### PR DESCRIPTION
See https://github.com/contentful/contentful-merge/pull/231
We don't need this workaround anymore.