### PR TITLE
feat: remove optional limit parameter [PHX-2761]

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,22 +108,19 @@ USAGE
 Create Entries Changeset
 
 USAGE
-  $ contentful-merge create --space <value> --source <value> --target <value> --cda-token <value> [--limit <value>]
+  $ contentful-merge create --space <value> --source <value> --target <value> --cda-token <value>
 
 FLAGS
   --space=<value>      [required] Space id
   --source=<value>     [required] Source environment id
   --target=<value>     [required] Target environment id
   --cda-token=<value>  [required, defaults to env: $CDA_TOKEN] CDA token
-  --limit=<value>      [default: 200] Limit parameter for collection endpoints
 
 DESCRIPTION
   Create Entries Changeset
 
 EXAMPLES
   $ contentful-merge create --space "<space id>" --source "<source environment id>" --target "<target environment id>" --cda-token <cda token>
-
-  $ contentful-merge create --space "<space id>" --source "<source environment id>" --target "<target environment id>" --cda-token <cda token> --limit 100
 ```
 
 
@@ -149,7 +146,7 @@ COMMANDS
 
 > ⚠️ As this project is still in beta, the data structure might still change down the line ⚠️
 
-The created changeset will be saved in JSON format in a file called `changeset.json` in the directory that you run the command in. It has the following basic structure: 
+The created changeset will be saved in JSON format in a file called `changeset.json` in the directory that you run the command in. It has the following basic structure:
 ```javascript
 {
   "sys": {

--- a/src/commands/create/index.ts
+++ b/src/commands/create/index.ts
@@ -57,7 +57,6 @@ export default class Create extends Command {
 
   static examples = [
     'contentful-merge create --space "<space id>" --source "<source environment id>" --target "<target environment id>" --cda-token <cda token>',
-    'contentful-merge create --space "<space id>" --source "<source environment id>" --target "<target environment id>" --cda-token <cda token> --limit 100',
   ]
 
   static flags = {
@@ -69,7 +68,6 @@ export default class Create extends Command {
       required: true,
       env: 'CDA_TOKEN',
     }),
-    limit: Flags.integer({ description: 'Limit parameter for collection endpoints', required: false, default: 200 }),
   }
 
   private async writeFileLog() {
@@ -105,7 +103,7 @@ export default class Create extends Command {
     const context: CreateChangesetContext = {
       logger: this.logger,
       client,
-      limit: flags.limit,
+      limit: 200,
       accessToken: flags.token,
       spaceId: flags.space,
       sourceEnvironmentId: flags.source,


### PR DESCRIPTION
We have a name clash that is confusing for users: 
- we enforce a "number of changes" `limit`
- we provide an optional `limit` related to the collections endpoint. 

To make things less confusing, we remove the optional `limit` parameter for now.