### PR TITLE
fix(docs): default install should be global []

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Takes a space id and two environment ids and creates a changeset which details a
 Prerequisite: node v18
 
 ```bash
-npm install contentful-merge
+npm install -g contentful-merge
 ```
 
 ## Usage


### PR DESCRIPTION
This is the recommendation also for the contentful-cli and therefore should be here as well.