### PR TITLE
chore: add first integration apply test for add wip

### DIFF
--- a/src/commands/apply/index.ts
+++ b/src/commands/apply/index.ts
@@ -24,6 +24,7 @@ export default class Apply extends Command {
     'contentful-merge apply changeset.json --space "<space-id>" --environment "staging"',
   ]
 
+  // How are args being passed into fancy?
   static args = {
     input: Args.string({ required: false, default: 'changeset.json' }),
   }

--- a/test/integration/commands/apply/changesets/1-add-entry.json
+++ b/test/integration/commands/apply/changesets/1-add-entry.json
@@ -1,0 +1,39 @@
+{
+  "sys": {
+    "type": "Changeset",
+    "createdAt": "1692107092473"
+  },
+  "items": [
+    {
+      "changeType": "add",
+      "entity": {
+        "sys": {
+          "type": "Link",
+          "linkType": "Entry",
+          "id": "4mfJMguVrMiQmZyeUdBbNu"
+        }
+      },
+      "data": {
+        "metadata": {
+          "tags": []
+        },
+        "sys": {
+          "id": "4mfJMguVrMiQmZyeUdBbNu",
+          "type": "Entry",
+          "contentType": {
+            "sys": {
+              "type": "Link",
+              "linkType": "ContentType",
+              "id": "author"
+            }
+          }
+        },
+        "fields": {
+          "name": {
+            "en-US": "Author 100"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/test/integration/commands/apply/index.test.ts
+++ b/test/integration/commands/apply/index.test.ts
@@ -1,0 +1,52 @@
+import { expect } from '@oclif/test'
+import { Environment, Space, createClient } from 'contentful-management'
+import fs from 'fs'
+import { ApplyTestContext, TestContext, createEnvironment } from './../bootstrap'
+import fancy from './../register-plugins'
+import path from 'path'
+
+const spaceId = process.env.CONTENTFUL_SPACE_ID!
+if (!spaceId) {
+  throw new Error('Please provide a `CONTENTFUL_SPACE_ID`')
+}
+
+const cmaToken = process.env.CONTENTFUL_INTEGRATION_TEST_CMA_TOKEN!
+if (!cmaToken) {
+  throw new Error('Please provide a `CONTENTFUL_INTEGRATION_TEST_CMA_TOKEN`')
+}
+
+// Should be dynamically created later.
+const changesetFilePath = path.join(__dirname, './changesets/1-add-entry.json')
+console.log({ changesetFilePath })
+let testContext: ApplyTestContext
+let testSpace: Space
+
+before(async () => {
+  const client = createClient({ accessToken: cmaToken })
+  testSpace = await client.getSpace(spaceId)
+  const { environmentId, teardown } = await createEnvironment(testSpace)
+  testContext = {
+    spaceId: testSpace.sys.id,
+    environmentId: environmentId,
+    changesetFilePath,
+    cmaToken,
+    teardown,
+  }
+})
+
+after(async () => {
+  console.log('Deleting test environments ...')
+  await Promise.all([testContext.teardown()])
+})
+
+describe('create - happy path', () => {
+  fancy
+    .stdout() // to print the output during testing use `.stdout({ print: true })`
+    .runApplyCommand(() => testContext)
+    .it('should add new entries to environment if specified in changeset', (ctx) => {
+      console.log('ctx.stout', ctx.stdout)
+      console.dir({ ctx }, { depth: null })
+      expect(ctx.stdout).to.contain('Changeset successfully applied 🎉')
+      // TODO Test that the data actually exists (e.g. by fetching via client)
+    })
+})

--- a/test/integration/commands/create/index.test.ts
+++ b/test/integration/commands/create/index.test.ts
@@ -1,8 +1,8 @@
 import { expect } from '@oclif/test'
 import { ApiKey, Space, createClient } from 'contentful-management'
 import fs from 'fs'
-import { TestContext, createCdaToken, createEnvironments } from './bootstrap'
-import fancy from './register-plugins'
+import { TestContext, createCdaToken, createEnvironments } from './../bootstrap'
+import fancy from './../register-plugins'
 
 const spaceId = process.env.CONTENTFUL_SPACE_ID!
 if (!spaceId) {

--- a/test/integration/commands/register-plugins.ts
+++ b/test/integration/commands/register-plugins.ts
@@ -1,8 +1,9 @@
 import { Config } from '@oclif/core'
 import type { ContentType, Entry, Environment } from 'contentful-management/types'
 import { fancy } from 'fancy-test'
-import CreateCommand from '../../../../src/commands/create'
-import { TestContext } from './bootstrap'
+import CreateCommand from '../../../src/commands/create'
+import ApplyCommand from '../../../src/commands/apply'
+import { ApplyTestContext, TestContext } from './bootstrap'
 
 const createTestContentType = async (env: Environment): Promise<ContentType> => {
   const contentTypeId = 'testType'
@@ -78,6 +79,31 @@ export default fancy
             testContext.targetEnvironment.sys.id,
             '--cda-token',
             cdaToken || testContext.cdaToken,
+          ],
+          {} as unknown as Config // Runtime config, but not required for tests.
+        )
+        try {
+          await cmd.run()
+        } catch (e) {
+          console.log(e)
+        }
+      },
+    }
+  })
+  .register('runApplyCommand', (getTestContext: () => ApplyTestContext) => {
+    return {
+      async run(ctx) {
+        const testContext = getTestContext()
+
+        const cmd = new ApplyCommand(
+          [
+            testContext.changesetFilePath,
+            '--space',
+            testContext.spaceId,
+            '--environment',
+            testContext.environmentId,
+            '--cma-token',
+            testContext.cmaToken,
           ],
           {} as unknown as Config // Runtime config, but not required for tests.
         )


### PR DESCRIPTION

### todos
- If we add more changesets as base for apply tests, we should not manually create them but make sure they are created with current create command logic.
- Types are all over the place and should be restructured
- Assertions that the entities actually exist in the target environment

### next prs
- all the other cases (delete, changed, all cases together, different failures)