### PR TITLE
feat: handle errors in apply command [PHX-2759]

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "prettier-fix": "prettier --config ./.prettierrc --write \"{**/*.js,**/*.ts,**/*.json}\"",
     "prepack": "npm run build && oclif manifest && oclif readme",
     "prepare": "husky install",
-    "test": "npm run test-unit && npm run test-integration",
+    "test": "npm run test-unit && npm run test-integration && npm run test-e2e",
     "test-integration": "mocha --exit test/integration/**/*.test.ts",
     "test-e2e": "mocha --exit test/e2e/**/*.test.ts",
     "test-integration-with-reports": "npm run test-integration -- --reporter mocha-junit-reporter --reporter-options mochaFile=reports/integration-results.xml",

--- a/src/engine/apply-changeset/actions/create-entity.ts
+++ b/src/engine/apply-changeset/actions/create-entity.ts
@@ -2,6 +2,7 @@ import { EntryProps } from 'contentful-management'
 import { omit } from 'lodash'
 import { LogLevel } from '../../logger/types'
 import { AddedChangesetItem, BaseActionParams } from '../../types'
+import { AddEntryError } from '../../errors'
 
 type CreateEntityParams = BaseActionParams & {
   item: AddedChangesetItem
@@ -30,5 +31,7 @@ export const createEntity = async ({
     task.output = `🚨 failed to create ${item.entity.sys.id}`
     logger.log(LogLevel.ERROR, `add entry ${item.entity.sys.id} failed with ${error}`)
     responseCollector.add(error.code, error)
+
+    throw new AddEntryError({ id: item.entity.sys.id, details: error.response?.data })
   }
 }

--- a/src/engine/apply-changeset/actions/delete-entity.ts
+++ b/src/engine/apply-changeset/actions/delete-entity.ts
@@ -1,3 +1,4 @@
+import { DeleteEntryError } from '../../errors'
 import { LogLevel } from '../../logger/types'
 import { BaseActionParams } from '../../types'
 
@@ -37,5 +38,7 @@ export const deleteEntity = async ({
     task.output = `🚨 failed to delete ${id}`
     logger.log(LogLevel.ERROR, `delete entry ${id} failed with ${error}`)
     responseCollector.add(error.code, error)
+
+    throw new DeleteEntryError({ id, details: error.response?.data })
   }
 }

--- a/src/engine/apply-changeset/actions/update-entity.ts
+++ b/src/engine/apply-changeset/actions/update-entity.ts
@@ -1,6 +1,7 @@
 import jsonpatch from 'fast-json-patch'
 import { LogLevel } from '../../logger/types'
 import { BaseActionParams, UpdatedChangesetItem } from '../../types'
+import { UpdateEntryError } from '../../errors'
 
 type UpdateEntityParams = BaseActionParams & {
   item: UpdatedChangesetItem
@@ -41,5 +42,7 @@ export const updateEntity = async ({
     task.output = `🚨 failed to update ${item.entity.sys.id}`
     logger.log(LogLevel.ERROR, `update entry ${item.entity.sys.id} failed with ${error}`)
     responseCollector.add(error.code, error)
+
+    throw new UpdateEntryError({ id: item.entity.sys.id, details: error.response?.data })
   }
 }

--- a/src/engine/apply-changeset/index.ts
+++ b/src/engine/apply-changeset/index.ts
@@ -28,7 +28,7 @@ export const applyChangesetTask = (context: ApplyChangesetContext): Listr => {
       rendererOptions: {
         timer: PRESET_TIMER,
         collapseSubtasks: false,
-        showErrorMessage: true,
+        showErrorMessage: false,
       },
     }
   )

--- a/src/engine/apply-changeset/tasks/create-load-changeset-task.ts
+++ b/src/engine/apply-changeset/tasks/create-load-changeset-task.ts
@@ -2,6 +2,7 @@ import { ListrTask } from 'listr2'
 import * as fs from 'node:fs/promises'
 import { LogLevel } from '../../logger/types'
 import { ApplyChangesetContext } from '../types'
+import { ChangesetFileError } from '../../errors'
 
 export const createLoadChangesetTask = (): ListrTask => {
   return {
@@ -10,9 +11,17 @@ export const createLoadChangesetTask = (): ListrTask => {
       task.output = `Loading data from ${context.inputPath}`
       context.logger.log(LogLevel.INFO, 'Start createLoadChangesetTask')
 
-      const changeset = await fs.readFile(context.inputPath, 'utf8').then((rawJson) => JSON.parse(rawJson))
-
-      context.changeset = changeset
+      try {
+        const changeset = await fs.readFile(context.inputPath, 'utf8').then((rawJson) => JSON.parse(rawJson))
+        context.changeset = changeset
+      } catch (error: any) {
+        context.logger.log(LogLevel.ERROR, `reading changeset file: ${error}`)
+        if (error.code === 'ENOENT') {
+          throw new ChangesetFileError(error.path)
+        } else {
+          throw error
+        }
+      }
     },
   }
 }

--- a/src/engine/create-changeset/tasks/create-affected-content-types-diverged-task.ts
+++ b/src/engine/create-changeset/tasks/create-affected-content-types-diverged-task.ts
@@ -2,7 +2,7 @@ import { CreateChangesetContext } from '../types'
 import { ListrTask } from 'listr2'
 import { LogLevel } from '../../logger/types'
 import { divergedContentTypeIdsOfAffectedEntries } from '../../utils/diverged-content-type-ids-of-affected-entries'
-import { ContentModelDivergedError } from '../errors'
+import { ContentModelDivergedError } from '../../errors'
 
 export function createAffectedContentTypesDivergedTask(): ListrTask {
   return {

--- a/src/engine/create-changeset/tasks/create-compute-ids-task.ts
+++ b/src/engine/create-changeset/tasks/create-compute-ids-task.ts
@@ -3,7 +3,7 @@ import { LogLevel } from '../../logger/types'
 import { CreateChangesetContext } from '../types'
 import { doesExceedLimits } from '../../utils/exceeds-limits'
 import { EntityType } from '../../types'
-import { LimitsExceededError } from '../errors'
+import { LimitsExceededError } from '../../errors'
 
 type ComputeIdsTaskProps = {
   entityType: EntityType

--- a/src/engine/errors.ts
+++ b/src/engine/errors.ts
@@ -2,7 +2,7 @@ import { AffectedEntities } from './create-changeset/types'
 
 export class ContentfulError extends Error {
   details: any
-  constructor(message: string, details: any) {
+  constructor(message: string, details?: any) {
     super(message)
     this.details = details
   }
@@ -68,5 +68,13 @@ export class AddEntryError extends MergeEntityError {
 export class UpdateEntryError extends MergeEntityError {
   constructor(context: MergeEntityErrorContext) {
     super(`An error occurred while updating an entry.`, context)
+  }
+}
+
+export class ChangesetFileError extends ContentfulError {
+  constructor(changesetFilePath: string) {
+    super(
+      `There is no changeset at the path you provided ("${changesetFilePath}").\nPlease provide the path to an existing changeset to the "--file" flag and try again.`
+    )
   }
 }

--- a/src/engine/errors.ts
+++ b/src/engine/errors.ts
@@ -1,4 +1,4 @@
-import { AffectedEntities } from './types'
+import { AffectedEntities } from './create-changeset/types'
 
 export class ContentfulError extends Error {
   details: any
@@ -38,5 +38,35 @@ export class ContentModelDivergedError extends ContentfulError {
     const details = { amount: divergedContentTypeIds.length }
     super(message, details)
     this.divergedContentTypeIds = divergedContentTypeIds
+  }
+}
+
+export interface MergeEntityErrorContext {
+  id: string
+  details: Record<any, any>
+}
+
+export class MergeEntityError extends ContentfulError {
+  public entryId: string
+  constructor(message: string, context: MergeEntityErrorContext) {
+    super(message, context.details)
+    this.entryId = context.id
+  }
+}
+
+export class DeleteEntryError extends MergeEntityError {
+  constructor(context: MergeEntityErrorContext) {
+    super(`An error occurred while deleting an entry.`, context)
+  }
+}
+export class AddEntryError extends MergeEntityError {
+  constructor(context: MergeEntityErrorContext) {
+    super(`An error occurred while adding an entry.`, context)
+  }
+}
+
+export class UpdateEntryError extends MergeEntityError {
+  constructor(context: MergeEntityErrorContext) {
+    super(`An error occurred while updating an entry.`, context)
   }
 }

--- a/src/engine/utils/render-error-output.ts
+++ b/src/engine/utils/render-error-output.ts
@@ -1,10 +1,12 @@
 import { AxiosError } from 'axios'
 import { OutputFormatter } from './output-formatter'
-import { ContentModelDivergedError, LimitsExceededError } from '../create-changeset/errors'
+import { ContentModelDivergedError, LimitsExceededError, MergeEntityError } from '../errors'
 import { entityStatRenderer } from './entity-stat-renderer'
 import { pluralizeContentType, pluralizeEntry } from './pluralize'
 import { icons } from './icons'
 import chalk from 'chalk'
+
+const red = (text: string) => OutputFormatter.error(text)
 
 const failedEntryChangeRenderer = entityStatRenderer({
   icon: icons.bulletPoint,
@@ -45,6 +47,15 @@ export function renderErrorOutputForApply(error: Error) {
   }
 
   output += OutputFormatter.error(errorMessage)
+
+  if (error instanceof MergeEntityError) {
+    const errorDetails = `\n\n${JSON.stringify(error.details, null, 2)}`
+    output += red(
+      `\nThe changeset was only partially applied. The merge was stopped due to the following error (entry id: ${error.entryId}):`
+    )
+
+    output += red(errorDetails)
+  }
 
   return output
 }

--- a/test/e2e/commands/index.test.ts
+++ b/test/e2e/commands/index.test.ts
@@ -4,7 +4,7 @@ import fs from 'fs'
 import { ApplyTestContext, TestContext, createEnvironments } from './../../integration/commands/bootstrap'
 import fancy from './../../integration/commands/register-plugins'
 
-describe('Apply command flow', () => {
+describe('Command flow - create and apply', () => {
   const spaceId = process.env.CONTENTFUL_SPACE_ID!
   if (!spaceId) {
     throw new Error('Please provide a `CONTENTFUL_SPACE_ID`')

--- a/test/integration/commands/bootstrap.ts
+++ b/test/integration/commands/bootstrap.ts
@@ -69,7 +69,8 @@ export const createEnvironments = async (testSpace: Space): Promise<TestContext 
   const targetEnvironment = await testUtils.createTestEnvironment(testSpace, randomId + '_target_environment')
   console.log('creating API keys...')
   const apiKey = await createCdaToken(testSpace, [targetEnvironment.sys.id, sourceEnvironment.sys.id])
-  console.log('all setup')
+  console.log('setup finished\n')
+
   return {
     sourceEnvironment,
     targetEnvironment,

--- a/test/integration/commands/register-plugins.ts
+++ b/test/integration/commands/register-plugins.ts
@@ -97,6 +97,7 @@ export default fancy
 
         const cmd = new ApplyCommand(
           [
+            '--file',
             testContext.changesetFilePath,
             '--space',
             testContext.spaceId,

--- a/test/unit/commands/create/index.test.ts
+++ b/test/unit/commands/create/index.test.ts
@@ -3,11 +3,7 @@ import { Config } from '@oclif/core'
 import CreateCommand from '../../../../src/commands/create'
 import { fancy } from 'fancy-test'
 import { AxiosError } from 'axios'
-import {
-  ContentModelDivergedError,
-  LimitsExceededContext,
-  LimitsExceededError,
-} from '../../../../src/engine/create-changeset/errors'
+import { ContentModelDivergedError, LimitsExceededContext, LimitsExceededError } from '../../../../src/engine/errors'
 import { MemoryLogger } from '../../../../src/engine/logger/memory-logger'
 
 import fs from 'node:fs/promises'

--- a/test/unit/engine/create-changeset/tasks/create-affected-content-types-diverged-task.test.ts
+++ b/test/unit/engine/create-changeset/tasks/create-affected-content-types-diverged-task.test.ts
@@ -4,7 +4,7 @@ import { expect } from 'chai'
 import { createAffectedContentTypesDivergedTask } from '../../../../../src/engine/create-changeset/tasks/create-affected-content-types-diverged-task'
 import { createCreateChangesetContext } from '../../../fixtures/create-changeset-context-fixture'
 import { beforeEach } from 'mocha'
-import { ContentModelDivergedError } from '../../../../../src/engine/create-changeset/errors'
+import { ContentModelDivergedError } from '../../../../../src/engine/errors'
 
 const CONTENT_TYPE_ID = 'affected-content-type'
 


### PR DESCRIPTION
This PR introduces some error handling to the apply command. 
It also turns the file path into a flag (`--file`).

Examples errors:

<img width="723" alt="image" src="https://github.com/contentful/contentful-merge/assets/33579339/73c243e7-784a-4c3d-91a7-90071ef94511">

______

<img width="723" alt="image" src="https://github.com/contentful/contentful-merge/assets/33579339/f211e967-2e2b-49bd-b650-473b0c3a4128">
