### PR TITLE
chore: fix underlaying patch library [PHX-2907]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/jsondiffpatch": "^1.4.1",
         "@oclif/core": "^2.11.6",
         "@oclif/plugin-help": "^5.2.15",
         "@oclif/plugin-plugins": "^3.1.8",
@@ -22,6 +21,7 @@
         "contentful-collection": "^0.0.4",
         "contentful-sdk-core": "^7.1.0",
         "fast-json-patch": "^3.1.1",
+        "generate-json-patch": "^1.1.0",
         "listr2": "^6.6.1",
         "lodash": "^4.17.21",
         "p-limit": "^3.1.0",
@@ -575,17 +575,6 @@
       },
       "engines": {
         "node": ">=14"
-      }
-    },
-    "node_modules/@contentful/jsondiffpatch": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@contentful/jsondiffpatch/-/jsondiffpatch-1.4.1.tgz",
-      "integrity": "sha512-haLivz4diuSHbffmnedvVuGFVWEh+2ufruj8n4WA8vH2fafvu1fDUjfpT0lMBwJW+VTvlwn6LNX0Jo1CZJ9Jqw==",
-      "dependencies": {
-        "diff-match-patch": "^1.0.5"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/@contentful/rich-text-types": {
@@ -8944,12 +8933,6 @@
         "node": ">=0.3.1"
       }
     },
-    "node_modules/diff-match-patch": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.5.tgz",
-      "integrity": "sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==",
-      "license": "Apache-2.0"
-    },
     "node_modules/dir-glob": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
@@ -10231,6 +10214,11 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/generate-json-patch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/generate-json-patch/-/generate-json-patch-1.1.0.tgz",
+      "integrity": "sha512-7c9MnIsJuyCM1ooG+AFhZXJc5sboGD1u3CB4Ilfd2u4IwwOO3pM03LUoOl8h/jPHYHBJUjtTAf3KEOHvXNnUzA=="
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
@@ -25643,14 +25631,6 @@
         "contentful-management": "^10.0.0"
       }
     },
-    "@contentful/jsondiffpatch": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@contentful/jsondiffpatch/-/jsondiffpatch-1.4.1.tgz",
-      "integrity": "sha512-haLivz4diuSHbffmnedvVuGFVWEh+2ufruj8n4WA8vH2fafvu1fDUjfpT0lMBwJW+VTvlwn6LNX0Jo1CZJ9Jqw==",
-      "requires": {
-        "diff-match-patch": "^1.0.5"
-      }
-    },
     "@contentful/rich-text-types": {
       "version": "16.2.0",
       "resolved": "https://registry.npmjs.org/@contentful/rich-text-types/-/rich-text-types-16.2.0.tgz",
@@ -31508,11 +31488,6 @@
       "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
       "dev": true
     },
-    "diff-match-patch": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.5.tgz",
-      "integrity": "sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw=="
-    },
     "dir-glob": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
@@ -32473,6 +32448,11 @@
         "strip-ansi": "^6.0.1",
         "wide-align": "^1.1.2"
       }
+    },
+    "generate-json-patch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/generate-json-patch/-/generate-json-patch-1.1.0.tgz",
+      "integrity": "sha512-7c9MnIsJuyCM1ooG+AFhZXJc5sboGD1u3CB4Ilfd2u4IwwOO3pM03LUoOl8h/jPHYHBJUjtTAf3KEOHvXNnUzA=="
     },
     "get-caller-file": {
       "version": "2.0.5",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "/oclif.manifest.json"
   ],
   "dependencies": {
-    "@contentful/jsondiffpatch": "^1.4.1",
     "@oclif/core": "^2.11.6",
     "@oclif/plugin-help": "^5.2.15",
     "@oclif/plugin-plugins": "^3.1.8",
@@ -32,6 +31,7 @@
     "contentful-collection": "^0.0.4",
     "contentful-sdk-core": "^7.1.0",
     "fast-json-patch": "^3.1.1",
+    "generate-json-patch": "^1.1.0",
     "listr2": "^6.6.1",
     "lodash": "^4.17.21",
     "p-limit": "^3.1.0",

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -1,4 +1,4 @@
-import { Patch } from '@contentful/jsondiffpatch'
+import { Patch } from 'generate-json-patch'
 import { ListrTaskWrapper } from 'listr2'
 import { createClient } from './client'
 import { ResponseStatusCollector } from './client/response-status-collector'

--- a/src/engine/utils/create-patch.ts
+++ b/src/engine/utils/create-patch.ts
@@ -1,13 +1,18 @@
 import { Entry } from 'contentful'
-import { generateJSONPatch } from 'generate-json-patch'
+import { generateJSONPatch, pathInfo } from 'generate-json-patch'
 
 export const createPatch = ({ targetEntry, sourceEntry }: { targetEntry: Entry<any>; sourceEntry: Entry<any> }) => {
   // Temp fix until the types from generate-json-patch are fixed
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
   return generateJSONPatch(targetEntry, sourceEntry, {
-    propertyFilter: function (name: string) {
-      return !['sys'].includes(name)
+    propertyFilter: function (name: string, context) {
+      const { length } = pathInfo(context.path)
+      // ignore sys prop on root level
+      if (length === 1) {
+        return !['sys'].includes(name)
+      }
+      return true
     },
   })
 }

--- a/src/engine/utils/create-patch.ts
+++ b/src/engine/utils/create-patch.ts
@@ -2,7 +2,7 @@ import { Entry } from 'contentful'
 import { generateJSONPatch, pathInfo } from 'generate-json-patch'
 
 export const createPatch = ({ targetEntry, sourceEntry }: { targetEntry: Entry<any>; sourceEntry: Entry<any> }) => {
-  // Temp fix until the types from generate-json-patch are fixed
+  // Temp ignore until the types from generate-json-patch are fixed
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
   return generateJSONPatch(targetEntry, sourceEntry, {
@@ -10,7 +10,7 @@ export const createPatch = ({ targetEntry, sourceEntry }: { targetEntry: Entry<a
       const { length } = pathInfo(context.path)
       // ignore sys prop on root level
       if (length === 1) {
-        return !['sys'].includes(name)
+        return !['sys', 'metadata'].includes(name)
       }
       return true
     },

--- a/src/engine/utils/create-patch.ts
+++ b/src/engine/utils/create-patch.ts
@@ -1,17 +1,13 @@
 import { Entry } from 'contentful'
-import { create as createDiffer, Delta, formatters as diffFormatters, Patch } from '@contentful/jsondiffpatch'
-
-const format: (delta: Delta | undefined) => Patch = diffFormatters.jsonpatch.format
-
-const entryDiff = createDiffer({
-  propertyFilter: function (name: string) {
-    return !['sys'].includes(name)
-  },
-  textDiff: {
-    minLength: Number.MAX_SAFE_INTEGER,
-  },
-})
+import { generateJSONPatch } from 'generate-json-patch'
 
 export const createPatch = ({ targetEntry, sourceEntry }: { targetEntry: Entry<any>; sourceEntry: Entry<any> }) => {
-  return format(entryDiff.diff(targetEntry, sourceEntry))
+  // Temp fix until the types from generate-json-patch are fixed
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  return generateJSONPatch(targetEntry, sourceEntry, {
+    propertyFilter: function (name: string) {
+      return !['sys'].includes(name)
+    },
+  })
 }

--- a/test/unit/engine/utils/create-patch.test.ts
+++ b/test/unit/engine/utils/create-patch.test.ts
@@ -19,6 +19,11 @@ describe('createPatch', () => {
     const patch = createPatch({ targetEntry, sourceEntry })
     expect(patch).to.deep.equal([
       {
+        op: 'replace',
+        path: '/fields/modules/en-US/4/sys/id',
+        value: '6gFiJvssqQ62CMYqECOu2M',
+      },
+      {
         op: 'add',
         path: '/fields/modules/en-US/5',
         value: {

--- a/test/unit/engine/utils/create-patch.test.ts
+++ b/test/unit/engine/utils/create-patch.test.ts
@@ -9,8 +9,8 @@ describe('createPatch', () => {
     const targetEntry = targetEntriesFixture.items[0] as unknown as Entry<any>
     const patch = createPatch({ targetEntry, sourceEntry })
     expect(patch).to.deep.equal([
-      { op: 'replace', path: '/fields/slug/en-US', value: 'home-page' },
       { op: 'replace', path: '/fields/title/en-US', value: 'Home page' },
+      { op: 'replace', path: '/fields/slug/en-US', value: 'home-page' },
     ])
   })
   it('creates a patch for added list items', () => {

--- a/test/unit/engine/utils/create-patch.test.ts
+++ b/test/unit/engine/utils/create-patch.test.ts
@@ -42,4 +42,14 @@ describe('createPatch', () => {
     const patch = createPatch({ targetEntry, sourceEntry })
     expect(patch).to.deep.equal([{ op: 'remove', path: '/fields/modules/en-US/2' }])
   })
+  it('creates a patch with ignored metadata', () => {
+    const sourceEntry = sourceEntriesFixture.items[0] as unknown as Entry<any>
+    const targetEntry = sourceEntriesFixture.items[0] as unknown as Entry<any>
+
+    sourceEntry.metadata = {
+      tags: [{ sys: { id: 'tag1', type: 'Link', linkType: 'Tag' } }],
+    }
+    const patch = createPatch({ targetEntry, sourceEntry })
+    expect(patch).to.length(0)
+  })
 })


### PR DESCRIPTION
Switch the underlaying library to generate JSON Patch objects for entities from different environments.