### PR TITLE
chore(ts): adjust comments, names and types []

### DIFF
--- a/src/commands/apply/index.ts
+++ b/src/commands/apply/index.ts
@@ -153,8 +153,6 @@ export default class Apply extends Command {
     await this.writeFileLog()
     this.log(renderFilePaths({ logFilePath: this.logFilePath }))
 
-    // analyticsCloseAndFlush has a very short timeout because it will
-    // otherwise trigger a rerender of the listr tasks on error exits
     await Promise.allSettled([Sentry.close(2000), analyticsCloseAndFlush(2000)])
   }
 }

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -4,6 +4,7 @@ import { createClient } from './client'
 import { ResponseStatusCollector } from './client/response-status-collector'
 import { ILogger } from './logger/types'
 import { MemoryLogger } from './logger/memory-logger'
+import { Entry } from 'contentful'
 
 export type Client = ReturnType<typeof createClient>
 
@@ -81,3 +82,6 @@ export type BaseActionParams = {
 export type CommandType = 'create-changeset' | 'apply-changeset'
 
 export type EntityType = Exclude<keyof ReturnType<typeof createClient>['cda'], 'requestCounts'>
+
+type EntryWithoutMetadata = Omit<Entry<any>, 'metadata'>
+export type EntryWithOptionalMetadata = EntryWithoutMetadata & { metadata?: any }

--- a/src/engine/utils/create-patch.ts
+++ b/src/engine/utils/create-patch.ts
@@ -1,7 +1,14 @@
-import { Entry } from 'contentful'
+import { ContentType, Entry } from 'contentful'
 import { generateJSONPatch, pathInfo } from 'generate-json-patch'
+import { EntryWithOptionalMetadata } from '../types'
 
-export const createPatch = ({ targetEntry, sourceEntry }: { targetEntry: Entry<any>; sourceEntry: Entry<any> }) => {
+export const createPatch = ({
+  targetEntity: targetEntry,
+  sourceEntity: sourceEntry,
+}: {
+  targetEntity: EntryWithOptionalMetadata | ContentType
+  sourceEntity: EntryWithOptionalMetadata | ContentType
+}) => {
   // Temp ignore until the types from generate-json-patch are fixed
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore

--- a/test/unit/engine/utils/create-patch.test.ts
+++ b/test/unit/engine/utils/create-patch.test.ts
@@ -7,7 +7,7 @@ describe('createPatch', () => {
   it('creates a patch for changed string values', () => {
     const sourceEntry = sourceEntriesFixture.items[0] as unknown as Entry<any>
     const targetEntry = targetEntriesFixture.items[0] as unknown as Entry<any>
-    const patch = createPatch({ targetEntry, sourceEntry })
+    const patch = createPatch({ targetEntity: targetEntry, sourceEntity: sourceEntry })
     expect(patch).to.deep.equal([
       { op: 'replace', path: '/fields/title/en-US', value: 'Home page' },
       { op: 'replace', path: '/fields/slug/en-US', value: 'home-page' },
@@ -16,7 +16,7 @@ describe('createPatch', () => {
   it('creates a patch for added list items', () => {
     const sourceEntry = sourceEntriesFixture.items[2] as unknown as Entry<any>
     const targetEntry = targetEntriesFixture.items[2] as unknown as Entry<any>
-    const patch = createPatch({ targetEntry, sourceEntry })
+    const patch = createPatch({ targetEntity: targetEntry, sourceEntity: sourceEntry })
     expect(patch).to.deep.equal([
       {
         op: 'replace',
@@ -39,7 +39,7 @@ describe('createPatch', () => {
   it('creates a patch for removed list items', () => {
     const sourceEntry = sourceEntriesFixture.items[3] as unknown as Entry<any>
     const targetEntry = targetEntriesFixture.items[4] as unknown as Entry<any>
-    const patch = createPatch({ targetEntry, sourceEntry })
+    const patch = createPatch({ targetEntity: targetEntry, sourceEntity: sourceEntry })
     expect(patch).to.deep.equal([{ op: 'remove', path: '/fields/modules/en-US/2' }])
   })
   it('creates a patch with ignored metadata', () => {
@@ -49,7 +49,7 @@ describe('createPatch', () => {
     sourceEntry.metadata = {
       tags: [{ sys: { id: 'tag1', type: 'Link', linkType: 'Tag' } }],
     }
-    const patch = createPatch({ targetEntry, sourceEntry })
+    const patch = createPatch({ targetEntity: targetEntry, sourceEntity: sourceEntry })
     expect(patch).to.length(0)
   })
 })


### PR DESCRIPTION
This adjusts a few more var names to be true to what they are actually doing. 

- Mainly, we make sure that within generic functions which interact with both content types and entries, we actually have the variable names reflect that, e.g. by calling a var `entity` instead of `entry`

- I also removed ts-ignore and because of that had to make sure that for patch generation functions params expectations are actually explicitly spelled out (they can be both content types as well as entries with or without metadata)

- Removed a comment which is no longer true and belongs to a workaround from a few months ago.