### PR TITLE
chore: remove failure count [PHX-2923]

### DIFF
--- a/src/engine/apply-changeset/tasks/create-add-entities-task.ts
+++ b/src/engine/apply-changeset/tasks/create-add-entities-task.ts
@@ -27,7 +27,7 @@ export const createAddEntitiesTask = (): ListrTask => {
         entries.map(async (item) => {
           return limiter(async () => {
             const createdEntry = await createEntity({ client, environmentId, logger, item, responseCollector, task })
-            task.title = `Adding ${++count}/${entityCount} entries (failures: ${responseCollector.errorsLength})`
+            task.title = `Adding ${++count}/${entityCount} entries`
 
             await publishEntity({ client, entity: createdEntry, environmentId, logger, responseCollector, task })
 

--- a/src/engine/apply-changeset/tasks/create-change-entities-task.ts
+++ b/src/engine/apply-changeset/tasks/create-change-entities-task.ts
@@ -24,7 +24,7 @@ export const createChangeEntitiesTask = (): ListrTask => {
         items.map(async (item) => {
           return limiter(async () => {
             const idofUpdated = await updateEntity({ client, environmentId, logger, item, responseCollector, task })
-            task.title = `Updating ${++count}/${entityCount} entries (failures: ${responseCollector.errorsLength})`
+            task.title = `Updating ${++count}/${entityCount} entries`
 
             return idofUpdated
           })

--- a/src/engine/apply-changeset/tasks/create-remove-entities-task.ts
+++ b/src/engine/apply-changeset/tasks/create-remove-entities-task.ts
@@ -25,7 +25,7 @@ export const createRemoveEntitiesTask = (): ListrTask => {
         ids.map(async (id) => {
           return limiter(async () => {
             const idOfDeleted = await deleteEntity({ client, environmentId, logger, id, responseCollector, task })
-            task.title = `Deleting ${++count}/${entityCount} entries (failures: ${responseCollector.errorsLength})`
+            task.title = `Deleting ${++count}/${entityCount} entries`
 
             return idOfDeleted
           })


### PR DESCRIPTION
We used to show a failure count during the apply command. 
As we now stop the merge after the first failure, the count is no longer necessary.