### PR TITLE
chore(): extend error handling for apply command [PHX-2922]

### DIFF
--- a/src/engine/apply-changeset/actions/create-entity.ts
+++ b/src/engine/apply-changeset/actions/create-entity.ts
@@ -32,6 +32,6 @@ export const createEntity = async ({
     logger.log(LogLevel.ERROR, `add entry ${item.entity.sys.id} failed with ${error}`)
     responseCollector.add(error.code, error)
 
-    throw new AddEntryError({ id: item.entity.sys.id, details: error.response?.data })
+    throw new AddEntryError({ id: item.entity.sys.id, originalError: error.response?.data })
   }
 }

--- a/src/engine/apply-changeset/actions/delete-entity.ts
+++ b/src/engine/apply-changeset/actions/delete-entity.ts
@@ -39,6 +39,6 @@ export const deleteEntity = async ({
     logger.log(LogLevel.ERROR, `delete entry ${id} failed with ${error}`)
     responseCollector.add(error.code, error)
 
-    throw new DeleteEntryError({ id, details: error.response?.data })
+    throw new DeleteEntryError({ id, originalError: error.response?.data })
   }
 }

--- a/src/engine/apply-changeset/actions/publish-entity.ts
+++ b/src/engine/apply-changeset/actions/publish-entity.ts
@@ -30,6 +30,6 @@ export const publishEntity = async ({
     logger.log(LogLevel.ERROR, `publish entry ${entity.sys.id} failed with ${error}`)
     responseCollector.add(error.code, error)
 
-    throw new PublishEntryError({ id: entity.sys.id, details: error.response?.data })
+    throw new PublishEntryError({ id: entity.sys.id, originalError: error.response?.data })
   }
 }

--- a/src/engine/apply-changeset/actions/update-entity.ts
+++ b/src/engine/apply-changeset/actions/update-entity.ts
@@ -43,6 +43,6 @@ export const updateEntity = async ({
     logger.log(LogLevel.ERROR, `update entry ${item.entity.sys.id} failed with ${error}`)
     responseCollector.add(error.code, error)
 
-    throw new UpdateEntryError({ id: item.entity.sys.id, details: error.response?.data })
+    throw new UpdateEntryError({ id: item.entity.sys.id, originalError: error.response?.data })
   }
 }

--- a/src/engine/errors.ts
+++ b/src/engine/errors.ts
@@ -55,14 +55,21 @@ export class ContentModelDivergedError extends ContentfulError {
 
 export interface MergeEntityErrorContext {
   id: string
-  details: Record<any, any>
+  originalError: Record<any, any>
+  extra?: string
 }
 
 export class MergeEntityError extends ContentfulError {
   public entryId: string
+  public extra: string | undefined
   constructor(message: string, context: MergeEntityErrorContext) {
-    super(message, context.details)
+    super(message, context.originalError)
+    this.extra = context.extra
     this.entryId = context.id
+
+    if (context.originalError.sys?.id?.includes('AccessTokenInvalid')) {
+      this.extra = `The CMA token you provided is invalid. Please make sure that your token is correct and not expired.`
+    }
   }
 }
 

--- a/src/engine/utils/render-error-output.ts
+++ b/src/engine/utils/render-error-output.ts
@@ -54,6 +54,8 @@ export function renderErrorOutputForApply(error: Error) {
       `\nThe changeset was only partially applied. The merge was stopped due to the following error (entry id: ${error.entryId}):`
     )
 
+    if (error.extra) output += red(`\n\n${error.extra}`)
+
     output += red(errorDetails)
   }
 


### PR DESCRIPTION
Extend error handling when apply command is failing. 

Before:
![image](https://github.com/contentful/contentful-merge/assets/93705529/dba86583-822e-4bce-a407-7865e50418dc)

After: 
<img width="1082" alt="image" src="https://github.com/contentful/contentful-merge/assets/93705529/b69db6a6-d210-494f-967e-54aada73f362">

