### PR TITLE
feat: better error message for version mismatch [PHX-2924]

### DIFF
--- a/src/engine/errors.ts
+++ b/src/engine/errors.ts
@@ -86,6 +86,9 @@ export class DeleteEntryError extends MergeEntityError {
 }
 export class AddEntryError extends MergeEntityError {
   constructor(context: MergeEntityErrorContext) {
+    if (context.originalError.sys?.id?.includes('VersionMismatch')) {
+      context.extra = `The entry you are trying to add already exists in the selected environment.`
+    }
     super(`An error occurred while adding an entry.`, context)
   }
 }


### PR DESCRIPTION
Adding a more useful error message for add entry errors when entry already exists.

<img width="733" alt="image" src="https://github.com/contentful/contentful-merge/assets/33579339/158076ba-5bea-46ad-bdcb-9771e3e79809">
