### PR TITLE
feat: validate locales compatibility [PHX-2921]

### DIFF
--- a/src/engine/apply-changeset/tasks/create-validate-changeset-task.ts
+++ b/src/engine/apply-changeset/tasks/create-validate-changeset-task.ts
@@ -1,8 +1,26 @@
 import { ListrTask } from 'listr2'
 import { ApplyChangesetContext } from '../types'
 import { changesetExceedsLimits } from '../../validations/exceeds-limits'
-import { LimitsExceededForApplyError } from '../../errors'
+import { LimitsExceededForApplyError, LocaleMissingForApplyError } from '../../errors'
 import { containsMetadata } from '../../validations/contains-metadata'
+
+async function validateLocales(context: ApplyChangesetContext) {
+  const sourceEnvironmentId = context.changeset.sys.source.sys.id
+
+  const [sourceLocales, targetLocales] = await Promise.all([
+    context.client.cma.locales.getMany({ environment: sourceEnvironmentId }),
+    context.client.cma.locales.getMany({ environment: context.environmentId }),
+  ])
+
+  if (sourceLocales.items.length !== targetLocales.items.length) {
+    return false
+  }
+
+  const sourceLocaleCodes = sourceLocales.items.map((locale) => locale.code)
+  const targetLocaleCodes = targetLocales.items.map((locale) => locale.code)
+
+  return sourceLocaleCodes.every((code) => targetLocaleCodes.includes(code))
+}
 
 export const createValidateChangesetTask = (): ListrTask => {
   return {
@@ -13,6 +31,12 @@ export const createValidateChangesetTask = (): ListrTask => {
       // We are only enforcing limits for entries atm as we do not create changesets for content types
       if (exceedsLimits) {
         throw new LimitsExceededForApplyError(context)
+      }
+
+      const areLocalesInSynch = await validateLocales(context)
+
+      if (!areLocalesInSynch) {
+        throw new LocaleMissingForApplyError(context)
       }
 
       containsMetadata(context)

--- a/src/engine/apply-changeset/tasks/create-validate-changeset-task.ts
+++ b/src/engine/apply-changeset/tasks/create-validate-changeset-task.ts
@@ -1,31 +1,9 @@
 import { ListrTask } from 'listr2'
 import { ApplyChangesetContext } from '../types'
 import { changesetExceedsLimits } from '../../validations/exceeds-limits'
-import { LimitsExceededForApplyError, LocaleMissingForApplyError, AuthorizationErrorForApply } from '../../errors'
+import { LimitsExceededForApplyError, LocaleMissingForApplyError } from '../../errors'
 import { containsMetadata } from '../../validations/contains-metadata'
-
-async function validateLocales(context: ApplyChangesetContext) {
-  const sourceEnvironmentId = context.changeset.sys.source.sys.id
-  let sourceLocales, targetLocales
-
-  try {
-    ;[sourceLocales, targetLocales] = await Promise.all([
-      context.client.cma.locales.getMany({ environment: sourceEnvironmentId }),
-      context.client.cma.locales.getMany({ environment: context.environmentId }),
-    ])
-  } catch (err) {
-    throw new AuthorizationErrorForApply(context)
-  }
-
-  if (sourceLocales.items.length !== targetLocales.items.length) {
-    return false
-  }
-
-  const sourceLocaleCodes = sourceLocales.items.map((locale) => locale.code)
-  const targetLocaleCodes = targetLocales.items.map((locale) => locale.code)
-
-  return sourceLocaleCodes.every((code) => targetLocaleCodes.includes(code))
-}
+import { validateLocales } from '../../validations/validate-locales'
 
 export const createValidateChangesetTask = (): ListrTask => {
   return {

--- a/src/engine/client/index.ts
+++ b/src/engine/client/index.ts
@@ -1,5 +1,5 @@
 import axios from 'axios'
-import { ContentTypeCollection, Entry, EntryCollection } from 'contentful'
+import { ContentTypeCollection, Entry, EntryCollection, Locale, LocaleCollection } from 'contentful'
 import { EntryProps } from 'contentful-management'
 import { createHttpClient, getUserAgentHeader } from 'contentful-sdk-core'
 import { pickBy } from 'lodash'
@@ -137,6 +137,13 @@ export const createClient = ({
               'X-Contentful-Version': entryVersion,
             },
           })
+        },
+      },
+      locales: {
+        getMany: async ({ environment }: ParamEnvironment) => {
+          count.cma++
+          const result = await cmaClient.get(`${environment}/locales`)
+          return result.data as LocaleCollection
         },
       },
     },

--- a/src/engine/errors.ts
+++ b/src/engine/errors.ts
@@ -14,6 +14,14 @@ export interface LimitsExceededContext {
   affectedEntities: AffectedEntities
 }
 
+export class AuthorizationErrorForApply extends ContentfulError {
+  constructor(context: ApplyChangesetContext) {
+    const message = `The CMA token you provided is invalid. Please make sure that your token is correct and not expired.`
+
+    super(message, context)
+  }
+}
+
 export class LimitsExceededForCreateError extends ContentfulError {
   constructor(context: LimitsExceededContext) {
     const entries = context.affectedEntities.entries

--- a/src/engine/errors.ts
+++ b/src/engine/errors.ts
@@ -15,10 +15,10 @@ export interface LimitsExceededContext {
 }
 
 export class AuthorizationErrorForApply extends ContentfulError {
-  constructor(context: ApplyChangesetContext) {
+  constructor(context: ApplyChangesetContext, extra?: any) {
     const message = `The CMA token you provided is invalid. Please make sure that your token is correct and not expired.`
 
-    super(message, context)
+    super(message, { context, extra })
   }
 }
 

--- a/src/engine/errors.ts
+++ b/src/engine/errors.ts
@@ -42,6 +42,17 @@ export class LimitsExceededForApplyError extends ContentfulError {
   }
 }
 
+export class LocaleMissingForApplyError extends ContentfulError {
+  constructor(context: ApplyChangesetContext) {
+    const message = `The source environment does not contain the same locales as the target environment.`
+    const details = {
+      sourceEnvironment: context.changeset.sys.source.sys.id,
+      targetEnvironment: context.environmentId,
+    }
+    super(message, details)
+  }
+}
+
 export class ContentModelDivergedError extends ContentfulError {
   public divergedContentTypeIds: string[]
   constructor(divergedContentTypeIds: string[]) {

--- a/src/engine/validations/validate-locales.ts
+++ b/src/engine/validations/validate-locales.ts
@@ -1,0 +1,25 @@
+import { ApplyChangesetContext } from '../apply-changeset/types'
+import { AuthorizationErrorForApply } from '../errors'
+
+export async function validateLocales(context: ApplyChangesetContext) {
+  const sourceEnvironmentId = context.changeset.sys.source.sys.id
+  let sourceLocales, targetLocales
+
+  try {
+    ;[sourceLocales, targetLocales] = await Promise.all([
+      context.client.cma.locales.getMany({ environment: sourceEnvironmentId }),
+      context.client.cma.locales.getMany({ environment: context.environmentId }),
+    ])
+  } catch (err) {
+    throw new AuthorizationErrorForApply(context)
+  }
+
+  if (sourceLocales.items.length !== targetLocales.items.length) {
+    return false
+  }
+
+  const sourceLocaleCodes = sourceLocales.items.map((locale) => locale.code)
+  const targetLocaleCodes = targetLocales.items.map((locale) => locale.code)
+
+  return sourceLocaleCodes.every((code) => targetLocaleCodes.includes(code))
+}

--- a/test/e2e/commands/index.test.ts
+++ b/test/e2e/commands/index.test.ts
@@ -77,7 +77,9 @@ describe('Command flow - create and apply', () => {
       cmaToken: 'invalid-token',
     }))
     .it('should fail to apply changes with invalid token', async (ctx) => {
-      expect(ctx.stdout).to.contain('Error: An error occurred while deleting an entry.')
+      expect(ctx.stdout).to.contain(
+        'Error: The CMA token you provided is invalid. Please make sure that your token is correct and not expired.'
+      )
     })
 
   fancy

--- a/test/integration/commands/apply/index.test.ts
+++ b/test/integration/commands/apply/index.test.ts
@@ -103,9 +103,11 @@ describe('create command', () => {
     })
 
   fancy
-    .stdout({ print: true })
+    .stdout()
     .runApplyCommand(() => testContextInvalidToken)
     .it('should fail applying if token is invalid', (ctx) => {
-      expect(ctx.stdout).to.contain('Error: An error occurred while adding an entry.')
+      expect(ctx.stdout).to.contain(
+        'Error: The CMA token you provided is invalid. Please make sure that your token is correct and not expired.'
+      )
     })
 })


### PR DESCRIPTION
## Summary 

- Adds Locales validation
- Run Locales validation within validate-changeset-task
- When management token fails it throws an Authorization error