### PR TITLE
feat(apply): add validate access task [PHX-2934]

### DIFF
--- a/src/engine/apply-changeset/index.ts
+++ b/src/engine/apply-changeset/index.ts
@@ -10,6 +10,7 @@ export const applyChangesetTask = (context: ApplyChangesetContext): Listr => {
         task: (ctx, task): Listr => {
           return task.newListr(
             [
+              ApplyChangesetTasks.createValidateAccessTask(),
               ApplyChangesetTasks.createLoadChangesetTask(),
               ApplyChangesetTasks.createValidateChangesetTask(),
               ApplyChangesetTasks.createRemoveEntitiesTask(),

--- a/src/engine/apply-changeset/tasks/create-validate-access-task.ts
+++ b/src/engine/apply-changeset/tasks/create-validate-access-task.ts
@@ -1,0 +1,21 @@
+import { ListrTask } from 'listr2'
+import { ApplyChangesetContext } from '../types'
+import { LogLevel } from '../../logger/types'
+import { AuthorizationErrorForApply } from '../../errors'
+
+export const createValidateAccessTask = (): ListrTask => {
+  return {
+    title: 'Validating access',
+    task: async (context: ApplyChangesetContext) => {
+      const { client, environmentId, logger } = context
+      logger.log(LogLevel.INFO, 'Start createValidateAccessTask')
+
+      try {
+        await client.cma.entries.getMany({ environment: environmentId, query: { limit: 1 } })
+      } catch (error) {
+        logger.log(LogLevel.ERROR, 'Access denied')
+        throw new AuthorizationErrorForApply(context)
+      }
+    },
+  }
+}

--- a/src/engine/apply-changeset/tasks/index.ts
+++ b/src/engine/apply-changeset/tasks/index.ts
@@ -3,6 +3,7 @@ import { createChangeEntitiesTask } from './create-change-entities-task'
 import { createLoadChangesetTask } from './create-load-changeset-task'
 import { createRemoveEntitiesTask } from './create-remove-entities-task'
 import { createValidateChangesetTask } from './create-validate-changeset-task'
+import { createValidateAccessTask } from './create-validate-access-task'
 
 /**
  * @description This module imports various task-creation functions related to applying changesets.
@@ -11,6 +12,7 @@ import { createValidateChangesetTask } from './create-validate-changeset-task'
  * @property {function} createLoadChangesetTask
  * @property {function} createChangeEntitiesTask
  * @property {function} createAddEntitiesTask
+ * @property {function} createValidateAccessTask
  */
 
 export const ApplyChangesetTasks = {
@@ -19,4 +21,5 @@ export const ApplyChangesetTasks = {
   createLoadChangesetTask,
   createChangeEntitiesTask,
   createAddEntitiesTask,
+  createValidateAccessTask,
 }

--- a/src/engine/errors.ts
+++ b/src/engine/errors.ts
@@ -14,6 +14,14 @@ export interface LimitsExceededContext {
   affectedEntities: AffectedEntities
 }
 
+export class AuthorizationErrorForApply extends ContentfulError {
+  constructor(context: ApplyChangesetContext) {
+    const message = `The CMA token you provided is invalid. Please make sure that your token is correct and not expired.`
+
+    super(message, context)
+  }
+}
+
 export class LimitsExceededForCreateError extends ContentfulError {
   constructor(context: LimitsExceededContext) {
     const entries = context.affectedEntities.entries

--- a/test/e2e/commands/index.test.ts
+++ b/test/e2e/commands/index.test.ts
@@ -77,7 +77,9 @@ describe('Command flow - create and apply', () => {
       cmaToken: 'invalid-token',
     }))
     .it('should fail to apply changes with invalid token', async (ctx) => {
-      expect(ctx.stdout).to.contain('Error: An error occurred while deleting an entry.')
+      expect(ctx.stdout).to.contain(
+        'Error: The CMA token you provided is invalid. Please make sure that your token is correct and not expired.'
+      )
     })
 
   fancy

--- a/test/integration/commands/apply/index.test.ts
+++ b/test/integration/commands/apply/index.test.ts
@@ -106,6 +106,8 @@ describe('create command', () => {
     .stdout({ print: true })
     .runApplyCommand(() => testContextInvalidToken)
     .it('should fail applying if token is invalid', (ctx) => {
-      expect(ctx.stdout).to.contain('Error: An error occurred while adding an entry.')
+      expect(ctx.stdout).to.contain(
+        'Error: The CMA token you provided is invalid. Please make sure that your token is correct and not expired.'
+      )
     })
 })


### PR DESCRIPTION
## Summary

Currently we don't check if the provided management token works, and it fails at the first point in the workflow where we need to fetch information from contentful.

We added a task that validates the token as the **first step in the workflow,** the idea is that we can be sure that the following tasks should no have `authorization` issues since they should be capture at the beginning.

<img width="767" alt="Screenshot 2023-10-25 at 14 11 47" src="https://github.com/contentful/contentful-merge/assets/8948313/8d076fe1-aaf8-4b48-bc4b-039a794b0193">
