### PR TITLE
chore: add packages-read to contentful vault-secrets

### DIFF
--- a/.contentful/vault-secrets.yaml
+++ b/.contentful/vault-secrets.yaml
@@ -6,3 +6,4 @@ services:
   circleci:
     policies:
     - semantic-release-ecosystem
+    - packages-read


### PR DESCRIPTION
The first PR to migrate from npm packages to github packages according to this [guide](https://contentful.atlassian.net/wiki/spaces/ENG/pages/4396155213/Migrating+to+GitHub+Packages+from+npmjs)