### PR TITLE
fix: fix delimiter for query entries parameter [DANTE-1661]

### DIFF
--- a/src/commands/create/index.ts
+++ b/src/commands/create/index.ts
@@ -42,7 +42,7 @@ export default class Create extends Command {
   }
 
   static examples = [
-    'contentful-merge create --space "<space id>" --source "<source environment id>" --target "<target environment id>" --cda-token <cda token> --output-file <output file path> --query-entries "content_type: <content type id>" --allowed-operations=add --allowed-operations=delete',
+    'contentful-merge create --space "<space id>" --source "<source environment id>" --target "<target environment id>" --cda-token <cda token> --output-file <output file path> --query-entries "content_type=<content type id>" --allowed-operations=add --allowed-operations=delete',
   ]
 
   static flags = {

--- a/src/engine/create-changeset/tasks/create-fetch-partial-entities-task.ts
+++ b/src/engine/create-changeset/tasks/create-fetch-partial-entities-task.ts
@@ -17,7 +17,12 @@ type ExecuteParams = {
 function clearQueryEntries(queryEntries?: string[]) {
   if (!queryEntries) return {}
   return queryEntries.reduce((acc, entry) => {
-    const splitInput = entry.split(':')
+    const splitInput = entry.split('=')
+
+    if (splitInput.length !== 2) {
+      return acc
+    }
+
     const key = splitInput[0].trim()
     const value = splitInput[1].trim()
     return { ...acc, [key]: value }

--- a/test/integration/commands/bootstrap.ts
+++ b/test/integration/commands/bootstrap.ts
@@ -10,6 +10,7 @@ export type TestContext = {
   spaceId: string
   teardown: () => Promise<void>
   changesetFilePath: string
+  queryEntries?: string
 }
 
 export type ApplyTestContext = {

--- a/test/integration/commands/create/index.test.ts
+++ b/test/integration/commands/create/index.test.ts
@@ -81,4 +81,28 @@ describe('create command', () => {
     .it('fails and informs on 404', (ctx) => {
       expect(ctx.stdout).to.contain('Request failed with status code 404')
     })
+
+  fancy
+    .stdout()
+    .runCreateCommand(() => ({
+      ...testContext,
+      queryEntries: 'content_type=testType',
+    }))
+    .it('should find an entry with query entries parameter set to a valid content type', (ctx) => {
+      expect(ctx.stdout).to.contain('Changeset successfully created 🎉')
+      expect(ctx.stdout).to.contain('1 added entry')
+      expect(ctx.stdout).to.contain('0 updated entries')
+      expect(ctx.stdout).to.contain('0 deleted entries')
+      expect(fs.existsSync(changesetPath)).to.be.true
+    })
+
+  fancy
+    .stdout()
+    .runCreateCommand(() => ({
+      ...testContext,
+      queryEntries: 'content_type=INVALID',
+    }))
+    .it('should not find any entries with query entries parameter set to invalid content type', (ctx) => {
+      expect(ctx.stdout).to.contain('Request failed with status code 400')
+    })
 })

--- a/test/integration/commands/register-plugins.ts
+++ b/test/integration/commands/register-plugins.ts
@@ -81,6 +81,8 @@ export default fancy
             cdaToken || testContext.cdaToken,
             '--output-file',
             testContext.changesetFilePath,
+            '--query-entries',
+            testContext.queryEntries || '',
           ],
           {} as unknown as Config, // Runtime config, but not required for tests.
         )


### PR DESCRIPTION
Delimiter for query-entries parameter was inconsistent - in some places it was ":" and "=" in others, we need to unify it, to make it the same pattern as contentful-export I went with "="