### PR TITLE
fix: only create patch for 'fields' property of entities

### DIFF
--- a/src/engine/utils/create-patch.ts
+++ b/src/engine/utils/create-patch.ts
@@ -1,4 +1,4 @@
-import { ContentType, Entry } from 'contentful'
+import { ContentType } from 'contentful'
 import { generateJSONPatch, pathInfo } from 'generate-json-patch'
 import { EntryWithOptionalMetadata } from '../types'
 
@@ -15,9 +15,9 @@ export const createPatch = ({
   return generateJSONPatch(targetEntry, sourceEntry, {
     propertyFilter: function (name: string, context) {
       const { length } = pathInfo(context.path)
-      // ignore sys prop on root level
+      // only create patch for `fields` property
       if (length === 1) {
-        return !['sys', 'metadata'].includes(name)
+        return name === 'fields'
       }
       return true
     },


### PR DESCRIPTION
A customer had an issue where `contentful-merge create` would error due to the fact that the `displayField` property of the content type in the target environment was different. However, we are not interested in changes to top-level properties of the content type that are not related to `fields`.

Therefore I changed the filter to explicitly create a patch for the changes in the `fields` property 