### PR TITLE
fix(reporting): send correct measurements [FUS-543]

### DIFF
--- a/src/commands/apply/index.ts
+++ b/src/commands/apply/index.ts
@@ -155,15 +155,15 @@ export default class Apply extends Command {
     })
 
     await applyChangesetTask(context).run()
-    transaction?.finish()
     const endTime = performance.now()
-    const duration = ((endTime - startTime) / 1000).toFixed(1)
 
-    Sentry.setTag('added', context.processedEntities.entries.added.length)
-    Sentry.setTag('removed', context.processedEntities.entries.deleted.length)
-    Sentry.setTag('changed', context.processedEntities.entries.updated.length)
-    Sentry.setTag('cmaRequest', client.requestCounts().cma)
-    Sentry.setTag('duration', `${duration}`)
+    Sentry.setMeasurement('added', context.processedEntities.entries.added.length, 'none')
+    Sentry.setMeasurement('removed', context.processedEntities.entries.deleted.length, 'none')
+    Sentry.setMeasurement('changed', context.processedEntities.entries.updated.length, 'none')
+    Sentry.setMeasurement('cmaRequest', client.requestCounts().cma, 'none')
+    Sentry.setMeasurement('duration', endTime - startTime, 'millisecond')
+
+    transaction?.finish()
 
     trackApplyCommandCompleted({
       space_key: flags.space,

--- a/src/commands/create/index.ts
+++ b/src/commands/create/index.ts
@@ -190,7 +190,7 @@ export default class Create extends Command {
     Sentry.setMeasurement('changed', context.affectedEntities.entries.changed.length, 'none')
     Sentry.setMeasurement('cdaRequest', client.requestCounts().cda, 'none')
     Sentry.setMeasurement('cmaRequest', client.requestCounts().cma, 'none')
-    Sentry.setMeasurement('memory', usedMemory, 'kilobyte')
+    Sentry.setMeasurement('memory', usedMemory, 'megabyte')
     Sentry.setMeasurement('duration', endTime - startTime, 'millisecond')
     Sentry.setExtra('statistics', context.statistics)
 

--- a/src/commands/create/index.ts
+++ b/src/commands/create/index.ts
@@ -181,21 +181,20 @@ export default class Create extends Command {
 
     await createChangesetTaskInstance.run()
 
-    transaction?.finish()
-
     const endTime = performance.now()
-    const duration = ((endTime - startTime) / 1000).toFixed(1)
     const usedMemory = process.memoryUsage().heapUsed / 1024 / 1024
 
-    Sentry.setTag('added', context.affectedEntities.entries.added.length)
-    Sentry.setTag('removed', context.affectedEntities.entries.removed.length)
-    Sentry.setTag('maybeChanged', context.affectedEntities.entries.maybeChanged.length)
-    Sentry.setTag('changed', context.affectedEntities.entries.changed.length)
-    Sentry.setTag('cdaRequest', client.requestCounts().cda)
-    Sentry.setTag('cmaRequest', client.requestCounts().cma)
-    Sentry.setTag('memory', usedMemory.toFixed(2))
-    Sentry.setTag('duration', `${duration}`)
+    Sentry.setMeasurement('added', context.affectedEntities.entries.added.length, 'none')
+    Sentry.setMeasurement('removed', context.affectedEntities.entries.removed.length, 'none')
+    Sentry.setMeasurement('maybeChanged', context.affectedEntities.entries.maybeChanged.length, 'none')
+    Sentry.setMeasurement('changed', context.affectedEntities.entries.changed.length, 'none')
+    Sentry.setMeasurement('cdaRequest', client.requestCounts().cda, 'none')
+    Sentry.setMeasurement('cmaRequest', client.requestCounts().cma, 'none')
+    Sentry.setMeasurement('memory', usedMemory, 'kilobyte')
+    Sentry.setMeasurement('duration', endTime - startTime, 'millisecond')
     Sentry.setExtra('statistics', context.statistics)
+
+    transaction?.finish()
 
     trackCreateCommandCompleted({
       space_key: flags.space,

--- a/src/engine/apply-changeset/tasks/create-validate-changeset-task.ts
+++ b/src/engine/apply-changeset/tasks/create-validate-changeset-task.ts
@@ -16,9 +16,9 @@ export const createValidateChangesetTask = (): ListrTask => {
         throw new LimitsExceededForApplyError(context)
       }
 
-      const areLocalesInSynch = await validateLocales(context)
+      const areLocalesInSync = await validateLocales(context)
 
-      if (!areLocalesInSynch) {
+      if (!areLocalesInSync) {
         throw new LocaleMissingForApplyError(context)
       }
 


### PR DESCRIPTION
Set numeric metric as measurement for evaluations. (tags are always strings and can not be used in a computational way in sentry)