### PR TITLE
fix: extract links from rich text field [FUS-556]

### DIFF
--- a/test/integration/commands/apply/index.test.ts
+++ b/test/integration/commands/apply/index.test.ts
@@ -6,7 +6,7 @@ import fancy from './../register-plugins'
 import { createChangeset } from '../../../../src/engine/utils/create-changeset'
 import { createAddTwoItemsChangeset } from '../fixtures/add-two-items-changeset'
 
-describe('create command', () => {
+describe('apply command', () => {
   const spaceId = process.env.CONTENTFUL_SPACE_ID!
   if (!spaceId) {
     throw new Error('Please provide a `CONTENTFUL_SPACE_ID`')

--- a/test/unit/engine/utils/sort-entries-by-reference.test.ts
+++ b/test/unit/engine/utils/sort-entries-by-reference.test.ts
@@ -6,6 +6,7 @@ import { createChangesetItemWithData } from '../../../../src/test/helpers/create
 describe('sortEntriesByReference', () => {
   const referencedItem: AddedChangesetItem = createChangesetItemWithData('lesson', 'added-entry')
   const referencedItem1: AddedChangesetItem = createChangesetItemWithData('lesson', 'added-entry1')
+  const referencedItem2: AddedChangesetItem = createChangesetItemWithData('lesson', 'added-entry2')
   const itemWithOneLink: AddedChangesetItem = createChangesetItemWithData('lesson1', 'added-entry-with-one-link', {
     referenceField: {
       'en-US': {
@@ -34,6 +35,68 @@ describe('sortEntriesByReference', () => {
       referenceField: {
         'en-US': {
           sys: { type: 'Link', linkType: 'Entry', id: 'random-entry' },
+        },
+      },
+    },
+  )
+
+  const itemWithRichTextLinks: AddedChangesetItem = createChangesetItemWithData(
+    'lesson4',
+    'added-entry-with-rich-text-link',
+    {
+      richTextField: {
+        'en-US': {
+          nodeType: 'document',
+          data: {},
+          content: [
+            {
+              nodeType: 'embedded-entry-inline',
+              content: [],
+              data: {
+                target: {
+                  sys: {
+                    type: 'Link',
+                    linkType: 'Entry',
+                    id: 'added-entry',
+                  },
+                },
+              },
+            },
+            { nodeType: 'text', marks: [], value: 'some text', data: {} },
+            {
+              nodeType: 'paragraph',
+              content: [
+                { nodeType: 'text', marks: [], value: 'some text', data: {} },
+                {
+                  nodeType: 'embedded-entry-block',
+                  content: [],
+                  data: {
+                    target: {
+                      sys: {
+                        type: 'Link',
+                        linkType: 'Entry',
+                        id: 'added-entry1',
+                      },
+                    },
+                  },
+                },
+                {
+                  nodeType: 'entry-hyperlink',
+                  content: [],
+                  data: {
+                    target: {
+                      sys: {
+                        type: 'Link',
+                        linkType: 'Entry',
+                        id: 'added-entry2',
+                      },
+                    },
+                  },
+                },
+              ],
+              data: {},
+            },
+          ],
         },
       },
     },
@@ -79,7 +142,7 @@ describe('sortEntriesByReference', () => {
     ])
   })
 
-  it('should not reorder there are no links in the changeset', () => {
+  it('should not reorder if there are no links in the changeset', () => {
     expect(sortEntriesByReference([nonReferencedItem, referencedItem, referencedItem1])).to.deep.equal([
       nonReferencedItem,
       referencedItem,
@@ -119,5 +182,11 @@ describe('sortEntriesByReference', () => {
       itemWithOneLink,
       itemWithArrayLinks,
     ])
+  })
+
+  it('should reorder entries linked in rich text fields', () => {
+    expect(
+      sortEntriesByReference([itemWithRichTextLinks, referencedItem, referencedItem1, referencedItem2]),
+    ).to.deep.equal([referencedItem, referencedItem1, referencedItem2, itemWithRichTextLinks])
   })
 })


### PR DESCRIPTION
The Merge App performs a sorting during `apply` command that puts all entries with links to other entries at the end of the list to ensure that all the links are published before the main entry. This however was not the case for rich text fields, which caused issues with merging.

This PR introduces a function that detects links to other entries in rich text field and sorts them down accordingly.