### PR TITLE
chore: change ci-alert-slack target to new slack channel [COPS-995]

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     circleci.com/project-slug: github/contentful/contentful-merge
     github.com/project-slug: contentful/contentful-merge
-    contentful.com/ci-alert-slack: prd-fusion-bots
+    contentful.com/ci-alert-slack: prd-content-ops-bots
 spec:
   type: cli
   lifecycle: experimental


### PR DESCRIPTION
Updates the alert target to #prd-content-ops-bots