### PR TITLE
chore: bump github-auto-merge to v2 [COPS-1542]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,6 @@
 *   @contentful/team-content-operations
+
+# Do not assign anyone to these files otherwise
+# there would be review requests for all dependabot PRs
+package.json
+package-lock.json

--- a/.github/workflows/dependabot-approve-and-request-merge.yaml
+++ b/.github/workflows/dependabot-approve-and-request-merge.yaml
@@ -7,9 +7,10 @@ jobs:
     permissions:
       contents: write
       id-token: write
+      pull-requests: write
     runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'
     steps:
-      - uses: contentful/github-auto-merge@v1
+      - uses: contentful/github-auto-merge@b995e4ecd10bed72105998808b1fe666d6b0892d # v2
         with:
           VAULT_URL: ${{ secrets.VAULT_URL }}


### PR DESCRIPTION
Bump automatic approval and merge workflow for Dependabot PRs version to v2. Do not assign team for a review.

https://contentful.atlassian.net/browse/COPS-1542
