### PR TITLE
fix(sentry): preserve test node env in mocha bootstrap [COPS-1543]

### DIFF
--- a/test/helpers/init.js
+++ b/test/helpers/init.js
@@ -1,6 +1,6 @@
 const path = require('path')
 process.env.TS_NODE_PROJECT = path.resolve('test/tsconfig.json')
-process.env.NODE_ENV = 'development'
+process.env.NODE_ENV = process.env.NODE_ENV || 'development'
 
 global.oclif = global.oclif || {}
 global.oclif.columns = 80


### PR DESCRIPTION
## Summary
- preserve an explicitly provided `NODE_ENV` in the mocha bootstrap
- keep `development` only as the fallback for ad-hoc local mocha runs
- stop repo-local test setup from re-enabling Sentry during tests

## Ticket
https://contentful.atlassian.net/browse/COPS-1543

## Why
The repo test scripts already set `NODE_ENV=test`, but mocha auto-loads `test/helpers/init.js` via `.mocharc.json`, and that file force-set `NODE_ENV=development`. Because the command modules initialize Sentry at import time, tests were flipping back to `development` before command imports, which left Sentry enabled and caused expected `cmd.catch(...)` test errors to be reported.

## Risk and Rollout
Low risk. Single-line test bootstrap change. Production code path unchanged. Rollout is normal merge/deploy; rollback is reverting this commit if needed.