### PR TITLE
fix: remove accidentally installed npm devDependency [EXT-7405]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,6 @@
         "lint-staged": "^15.0.2",
         "mocha": "^11.7.5",
         "mocha-junit-reporter": "^2.2.1",
-        "npm": "11.7.0",
         "oclif": "^4.17.30",
         "ora": "^9.3.0",
         "prettier": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "lint-staged": "^15.0.2",
     "mocha": "^11.7.5",
     "mocha-junit-reporter": "^2.2.1",
-    "npm": "11.7.0",
     "oclif": "^4.17.30",
     "ora": "^9.3.0",
     "prettier": "^3.0.0",


### PR DESCRIPTION
## Summary

- Removes the `npm` package (v11.7.0) from `devDependencies` — it was accidentally added (likely via `npm install npm`) and is not imported or required anywhere in the codebase.
- Reduces install footprint and avoids shipping a bundled copy of npm itself as a dev dependency.

## Verification

- Grepped all `.ts`, `.js`, `.mjs`, and `.cjs` files for `require('npm')`, `from 'npm'`, and `import 'npm'` — zero matches.
- `npm install` succeeds cleanly after removal.

## Test plan

- [x] CI passes (no source code changes, only dependency removal)
- [x] `npm install` completes without errors
- [x] Existing tests pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)