### PR TITLE
docs: add AGENTS.md, ARCHITECTURE.md, and a decision record

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,60 @@
+# AGENTS.md
+
+Guidance for AI coding agents working in this repository.
+
+## What this project is
+
+`contentful-merge` is an oclif-based CLI (`contentful-merge`) that diffs and merges Contentful entries
+across two environments in the same space. It has two commands:
+
+- `create` (`src/commands/create`) — compares a source and target environment, producing a changeset
+  JSON file describing adds/updates/deletes.
+- `apply` (`src/commands/apply`) — takes a changeset file and applies it against a target environment.
+
+## Where things live
+
+- `src/commands/` — oclif command definitions (flags, examples, wiring into the engine).
+- `src/engine/create-changeset/` — logic for diffing two environments into a changeset (`tasks/` holds the
+  individual Listr2 steps: fetch content types/entries, compute ids, detect changed/added entities).
+- `src/engine/apply-changeset/` — logic for applying a changeset (`tasks/` load/validate the changeset, then
+  remove/add/change entities; `actions/` are the low-level CMA calls; `warnings/` collect non-fatal issues).
+- `src/engine/client/` — thin wrapper around the Contentful Delivery (CDA) and Management (CMA) SDKs used by
+  both flows.
+- `src/engine/validations/` — pre-flight checks (locale mismatches, entity count limits, metadata usage).
+- `src/engine/logger/` — structured logging/output rendering used by the Listr2 task runner.
+- `src/analytics/` — Segment analytics wrapper; respects `DISABLE_ANALYTICS`.
+- `test/unit`, `test/integration`, `test/e2e` — see Testing below.
+
+## Build, lint, and test
+
+```bash
+npm install
+npm run build          # tsc build to dist/
+npm run check-types    # tsc, no emit
+npm run lint           # eslint src
+npm run test-unit      # mocha, no external calls
+npm run test-integration  # requires CONTENTFUL_INTEGRATION_TEST_CMA_TOKEN + CONTENTFUL_SPACE_ID
+npm run test-e2e
+npm test               # unit + integration + e2e
+```
+
+Run `npm run test-unit` after any engine or command change — it's the fast, dependency-free check. Only run
+integration/e2e tests if you have valid Contentful credentials in your environment; they hit real APIs.
+
+## Conventions
+
+- TypeScript, `strict: true`. Keep new code typed; avoid `any` unless mirroring an existing SDK type.
+- Task-based flows use [listr2](https://listr2.kilic.dev/); new steps in `create-changeset`/`apply-changeset`
+  should follow the existing `createXTask()` factory pattern in their respective `tasks/` folder.
+- Commits follow [Conventional Commits](https://www.conventionalcommits.org/) (`commitlint` + `semantic-release`
+  drive versioning off commit messages — do not hand-edit `package.json` version).
+- Formatting is enforced via Prettier + ESLint through `lint-staged`/husky pre-commit hooks; run
+  `npm run lint-fix` / `npm run prettier-fix` before committing if hooks flag issues.
+
+## Things to avoid
+
+- Don't add new dependencies without checking they're compatible with the `node >=24 <25` engine constraint.
+- Don't bypass the `--yes` confirmation flow removal in `apply` — it exists to prevent accidental destructive
+  changes to a target environment.
+- Don't commit generated files (`dist/`, `oclif.manifest.json`, `npm-shrinkwrap.json`) — they're build/release
+  artifacts.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,8 @@ integration/e2e tests if you have valid Contentful credentials in your environme
 ## Things to avoid
 
 - Don't add new dependencies without checking they're compatible with the `node >=24 <25` engine constraint.
-- Don't bypass the `--yes` confirmation flow removal in `apply` — it exists to prevent accidental destructive
-  changes to a target environment.
+- Don't remove or bypass the `apply` confirmation prompt — it exists to prevent accidental destructive
+  changes to a target environment. `--yes` is the explicit, user-supplied way to skip it; don't skip it any
+  other way.
 - Don't commit generated files (`dist/`, `oclif.manifest.json`, `npm-shrinkwrap.json`) — they're build/release
   artifacts.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -29,7 +29,7 @@ Builds a changeset describing the differences between a source and target enviro
    (`src/engine/client`), batched and paginated.
 2. **Compute ids** — entry/content-type ids present in one environment but not the other are classified as
    added/deleted.
-3. **Detect changes** — for ids present in both, `sys.changedAt` is compared first as a cheap filter; entries
+3. **Detect changes** — for ids present in both, `sys.updatedAt` is compared first as a cheap filter; entries
    that differ are then deep-compared and a JSON patch is generated (`fast-json-patch` /
    `generate-json-patch`) to capture the actual field-level diff.
 4. Each step above is a Listr2 task (`tasks/`), run sequentially so later steps can depend on earlier
@@ -47,8 +47,10 @@ Consumes a changeset file and replays it against a target environment via the CM
    usage — `src/engine/validations`).
 2. **Remove**, then **add**, then **change** entities, in that order, via `actions/` (thin wrappers around
    CMA create/update/publish/delete calls).
-3. Non-fatal issues encountered along the way are collected as **warnings** and rendered at the end rather
-   than aborting the run.
+3. Before any of the above runs, the changeset itself is checked for a fixed set of **warnings** (stale
+   creation date, target space/environment mismatch, applying to `master`) and these are rendered up front,
+   ahead of the confirmation prompt — they inform the user rather than aborting the run. Issues that occur
+   while actually applying entities are raised as errors, not warnings.
 
 Both flows use the same Listr2-based task/renderer pattern so progress and errors are displayed
 consistently in the terminal.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,83 @@
+# Architecture
+
+## Overview
+
+`contentful-merge` is a Node.js CLI, built on [oclif](https://oclif.io/), that lets a user diff two
+Contentful environments within a space and replay that diff (a "changeset") against a target environment.
+It's split into two independent flows — `create` and `apply` — that share a common engine layer.
+
+```
+bin/run  →  oclif  →  src/commands/{create,apply}  →  src/engine/{create-changeset,apply-changeset}
+                                                              │
+                                                              ▼
+                                                     src/engine/client (CDA/CMA)
+```
+
+## Command layer (`src/commands/`)
+
+Each subdirectory is an oclif command: declares flags/examples, validates input, and hands off to the
+corresponding engine entry point. Commands are the only place user-facing I/O (flags, prompts, exit codes)
+is handled.
+
+## Engine layer (`src/engine/`)
+
+### `create-changeset`
+
+Builds a changeset describing the differences between a source and target environment:
+
+1. **Fetch** — content types and entries are fetched in parallel from both environments via the CDA client
+   (`src/engine/client`), batched and paginated.
+2. **Compute ids** — entry/content-type ids present in one environment but not the other are classified as
+   added/deleted.
+3. **Detect changes** — for ids present in both, `sys.changedAt` is compared first as a cheap filter; entries
+   that differ are then deep-compared and a JSON patch is generated (`fast-json-patch` /
+   `generate-json-patch`) to capture the actual field-level diff.
+4. Each step above is a Listr2 task (`tasks/`), run sequentially so later steps can depend on earlier
+   results via the shared `CreateChangesetContext`.
+
+Output: a JSON changeset file (`sys` block identifying space/source/target, plus an `items` array of
+add/update/delete operations) — see the [data structure section](README.md#data-structure) in the README
+for the on-disk schema.
+
+### `apply-changeset`
+
+Consumes a changeset file and replays it against a target environment via the CMA client:
+
+1. **Load** the changeset from disk and **validate** it (locale compatibility, entity limits, metadata
+   usage — `src/engine/validations`).
+2. **Remove**, then **add**, then **change** entities, in that order, via `actions/` (thin wrappers around
+   CMA create/update/publish/delete calls).
+3. Non-fatal issues encountered along the way are collected as **warnings** and rendered at the end rather
+   than aborting the run.
+
+Both flows use the same Listr2-based task/renderer pattern so progress and errors are displayed
+consistently in the terminal.
+
+### `client`
+
+A single wrapper (`src/engine/client/index.ts`) around the `contentful` (Delivery API) and
+`contentful-management` (Management API) SDKs, adding batching, host configuration, and a consistent
+user-agent. This is the only module that talks to Contentful's APIs directly.
+
+### `logger`
+
+Structured log/output handling shared by both flows, used to feed Listr2's renderer and to produce the
+human-readable summaries printed at the end of a run.
+
+## Cross-cutting concerns
+
+- **Analytics** (`src/analytics/`): anonymous usage analytics via Segment, disabled with `DISABLE_ANALYTICS`
+  (set in all test scripts).
+- **Error handling** (`src/engine/errors.ts`, `utils/detect-error-level.ts`): CMA/CDA errors are classified
+  and rendered with `utils/render-error-output.ts` so partial failures during `apply` are visible per-entity.
+
+## Testing strategy
+
+- `test/unit` — engine/command logic in isolation, no network calls.
+- `test/integration` — exercises real CDA/CMA calls against a live space (requires credentials).
+- `test/e2e` — full CLI invocations via `bin/dev`, spanning `create` → `apply`.
+
+## Release
+
+Releases are automated via `semantic-release` on `main` (and a `next` prerelease channel), driven by
+Conventional Commit messages — there is no manual version bump.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
   <a href="#usage">Usage</a> |
   <a href="#commands">Commands</a> |
   <a href="#data-structure">Data structure</a> |
+  <a href="#documentation">Documentation</a> |
   <a href="#faq">FAQ</a> |
   <a href="#feedback">Feedback</a> |
   <a href="#code-of-conduct">Code of Conduct</a> |
@@ -65,8 +66,8 @@ Takes a space id and two environment ids and creates a changeset which details a
 - All requests are batched.
 - In order to identify <b>added</b> and <b>deleted</b> entries, entry ids are compared in both environments.
 - In order to identify <b>updated</b> entries, comparison happens in two steps:
-  The initial step involves identifying potentially diverging entries by examining the `sys.changedAt` property of all entries present in both environments.
-  Subsequently, for all entries with distinct `sys.changedAt` values, a more comprehensive comparison of their payload is performed. If any variations are found, a patch is generated to reflect the differences.
+  The initial step involves identifying potentially diverging entries by examining the `sys.updatedAt` property of all entries present in both environments.
+  Subsequently, for all entries with distinct `sys.updatedAt` values, a more comprehensive comparison of their payload is performed. If any variations are found, a patch is generated to reflect the differences.
 
 > <b>:bulb: Want to merge content types instead of entries? :bulb:</b>
 > We got you covered: Take a look at the [Merge App](https://www.contentful.com/marketplace/app/merge/) to your space, or, if you prefer the command line, check out the [Merge CLI](https://github.com/contentful/contentful-cli/tree/master/docs/merge).
@@ -282,6 +283,13 @@ Further limitations:
 - We only consider published entries during comparison, thus entries that are in draft state will not be compared.
 - Entries when added are immediately published.
 - Locales must be the same in the source and target environment.
+
+## Documentation
+
+- [ARCHITECTURE.md](ARCHITECTURE.md) — how the `create`/`apply` engine is structured.
+- [CONTRIBUTING.md](CONTRIBUTING.md) — local setup and running tests.
+- [AGENTS.md](AGENTS.md) — guidance for AI coding agents working in this repo.
+- [docs/decision-records](docs/decision-records) — architectural decisions and their rationale.
 
 ## FAQ
 

--- a/docs/decision-records/0001-two-phase-diff-then-detect-changed-content.md
+++ b/docs/decision-records/0001-two-phase-diff-then-detect-changed-content.md
@@ -1,0 +1,33 @@
+# 1. Detect changed entities via `sys.changedAt` before diffing payloads
+
+Date: 2026-08-25
+
+## Status
+
+Accepted
+
+## Context
+
+`contentful-merge create` needs to determine which entries/content types differ between a source and
+target environment. A space can contain a large number of entries, and computing a full field-level diff
+(JSON patch) for every entry that exists in both environments would mean fetching and deep-comparing the
+full payload of every shared entity on every run, even when the vast majority haven't changed.
+
+## Decision
+
+Change detection happens in two steps (`src/engine/create-changeset`):
+
+1. Fetch a partial representation of every content type/entry from both environments and compare
+   `sys.changedAt`. Entities whose timestamp differs are marked as *potentially* diverged.
+2. Only for that (typically much smaller) subset, fetch the full payload from both environments, strip
+   `sys` metadata, and generate an actual JSON patch (`fast-json-patch` / `generate-json-patch`). Entities
+   whose payload turns out to be identical despite a changed timestamp are dropped from the changeset.
+
+## Consequences
+
+- Avoids full-payload fetching/diffing for entities that haven't changed, which is the common case for a
+  large space with a small, targeted diff.
+- Adds a second network round-trip for entities that *did* change, since their full payload is fetched only
+  after the timestamp check.
+- Relies on `sys.changedAt` being a reliable signal of "might have changed"; it is expected to be a superset
+  of actually-changed entities (false positives are handled correctly by the payload diff), never a subset.

--- a/docs/decision-records/0001-two-phase-diff-then-detect-changed-content.md
+++ b/docs/decision-records/0001-two-phase-diff-then-detect-changed-content.md
@@ -1,4 +1,4 @@
-# 1. Detect changed entities via `sys.changedAt` before diffing payloads
+# 1. Detect changed entities via `sys.updatedAt` before diffing payloads
 
 Date: 2026-08-25
 
@@ -18,7 +18,7 @@ full payload of every shared entity on every run, even when the vast majority ha
 Change detection happens in two steps (`src/engine/create-changeset`):
 
 1. Fetch a partial representation of every content type/entry from both environments and compare
-   `sys.changedAt`. Entities whose timestamp differs are marked as *potentially* diverged.
+   `sys.updatedAt`. Entities whose timestamp differs are marked as *potentially* diverged.
 2. Only for that (typically much smaller) subset, fetch the full payload from both environments, strip
    `sys` metadata, and generate an actual JSON patch (`fast-json-patch` / `generate-json-patch`). Entities
    whose payload turns out to be identical despite a changed timestamp are dropped from the changeset.
@@ -29,5 +29,5 @@ Change detection happens in two steps (`src/engine/create-changeset`):
   large space with a small, targeted diff.
 - Adds a second network round-trip for entities that *did* change, since their full payload is fetched only
   after the timestamp check.
-- Relies on `sys.changedAt` being a reliable signal of "might have changed"; it is expected to be a superset
+- Relies on `sys.updatedAt` being a reliable signal of "might have changed"; it is expected to be a superset
   of actually-changed entities (false positives are handled correctly by the payload diff), never a subset.


### PR DESCRIPTION
## Summary
Adds the missing governance docs from the AI harness readiness rollout ([COPS-1906](https://contentful.atlassian.net/browse/COPS-1906)):
- `AGENTS.md` — repo map + build/test/lint commands for AI agents
- `ARCHITECTURE.md` — overview of the create/apply changeset engine
- `docs/decision-records/0001-two-phase-diff-then-detect-changed-content.md` — first ADR, documenting the existing changedAt-then-payload-diff approach

`CONTRIBUTING.md` already existed and meets the control bar, so no change was needed there.

## Test plan
- [x] Verified each new doc has ≥10 non-blank lines (control requirement)
- [x] No code changes, docs only

[COPS-1906]: https://contentful.atlassian.net/browse/COPS-1906?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ